### PR TITLE
Enhance the VirtioDevice trait to support PCI tranport layer

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -5,10 +5,45 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 use super::*;
-use std::sync::atomic::AtomicUsize;
-use std::sync::Arc;
 use vm_memory::GuestMemory;
 use vmm_sys_util::EventFd;
+
+/// Trait for virtio devices to inject interrupts into the guest.
+pub trait VirtioDeviceInterrupt: Sized + Send {
+    /// Inject the specified interrupt into the guest.
+    fn trigger(&mut self, interrupt_id: u32) -> std::io::Error;
+}
+
+/// Struct to encapsulate information for a single virtio queue.
+pub struct VirtioDeviceQueue<'a, M: GuestMemory> {
+    /// Virtio queue.
+    pub queue: Queue<'a, M>,
+    /// Eventfd for queue notification.
+    pub queue_evt: EventFd,
+    /// Id of the interrupt source to inject into the guest.
+    pub interrupt_id: u32,
+}
+
+/// Configuration information passed to VirtioDevice::activate().
+pub struct VirtioDeviceConfig<'a, M: GuestMemory, I: VirtioDeviceInterrupt> {
+    /// Object to access guest physical memory.
+    pub mem: M,
+    /// Virtio queues for the virtio device.
+    pub queues: Vec<VirtioDeviceQueue<'a, M>>,
+    /// Interrupt controller to inject interrupt into the guest.
+    pub intr_controller: I,
+}
+
+impl<'a, M, I> VirtioDeviceConfig<'a, M, I>
+where
+    M: GuestMemory,
+    I: VirtioDeviceInterrupt,
+{
+    /// Inject the specified interrupt into the guest.
+    pub fn trigger_intr(&mut self, interrupt_id: u32) -> std::io::Error {
+        self.intr_controller.trigger(interrupt_id)
+    }
+}
 
 /// Trait for virtio devices to be driven by a virtio transport.
 ///
@@ -22,11 +57,17 @@ pub trait VirtioDevice: Send {
     /// Associated guest memory
     type M: GuestMemory;
 
+    /// Associated type to inject interrupt into the guest.
+    type I: VirtioDeviceInterrupt;
+
     /// The virtio device type.
     fn device_type(&self) -> u32;
 
     /// The maximum size of each queue that this device supports.
     fn queue_max_sizes(&self) -> &[u16];
+
+    /// Get the number of interrupts required.
+    fn interrupt_count(&self) -> u32;
 
     /// The set of feature bits shifted by `page * 32`.
     fn features(&self, page: u32) -> u32 {
@@ -44,18 +85,11 @@ pub trait VirtioDevice: Send {
     fn write_config(&mut self, offset: u64, data: &[u8]);
 
     /// Activates this device for real usage.
-    fn activate<M: GuestMemory>(
-        &mut self,
-        mem: Self::M,
-        interrupt_evt: EventFd,
-        status: Arc<AtomicUsize>,
-        queues: Vec<Queue<M>>,
-        queue_evts: Vec<EventFd>,
-    ) -> ActivateResult;
+    fn activate(&mut self, config: VirtioDeviceConfig<Self::M, Self::I>) -> ActivateResult;
 
     /// Optionally deactivates this device and returns ownership of the guest memory map, interrupt
     /// event, and queue events.
-    fn reset(&mut self) -> Option<(EventFd, Vec<EventFd>)> {
+    fn reset(&mut self) -> Option<VirtioDeviceConfig<Self::M, Self::I>> {
         None
     }
 }


### PR DESCRIPTION
The VirtioDevice trait derived from the firecracker project is heavily
shaped by the MMIO transport layer. So enhance the VirtioDevice trait
to prepare for Virtio PCI transport layer. The key change is to support
multiple interrupts for a virtio device. And also encapsulate parameters
to VirtioDevice::activate() as VirtioDeviceConfig for readability.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>