### PR TITLE
device: Fix vmm_sys_util import

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -8,7 +8,7 @@ use super::*;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use vm_memory::GuestMemory;
-use vmm_sys_util::EventFd;
+use vmm_sys_util::eventfd::EventFd;
 
 /// Trait for virtio devices to be driven by a virtio transport.
 ///


### PR DESCRIPTION
We want to use the eventfd module.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>