### PR TITLE
Refine the VirtioDevice trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 extern crate epoll;
 #[macro_use]
 extern crate log;
+extern crate vm_device;
 extern crate vm_memory;
 extern crate vmm_sys_util;
 
@@ -31,4 +32,4 @@ pub enum ActivateError {
 }
 
 /// Virtio device activation result type.
-pub type ActivateResult = std::result::Result<(), ActivateError>;
+pub type ActivateResult<T> = std::result::Result<(), (ActivateError, T)>;


### PR DESCRIPTION
This is an RFC PR, which depends on https://github.com/rust-vmm/vm-device/pull/9 and https://github.com/rust-vmm/vm-device/pull/11

It refines the VirtioDevice trait to better support virtio backends.
Also introduce VirtioQueueConfig and VirtioDeviceConfig to manage
virtio device configuration information.

Signed-off-by: Xingjun Liu <xingjun.liu@linux.alibaba.com>
Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>