### PR TITLE
Enhancement to the virtio queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 byteorder = "=1.2.1"
-epoll = "=4.0.1"
 libc = ">=0.2.39"
 log = "=0.4.6"
 vm-memory = {version = ">=0.2.0", features = ["integer-atomics"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "=1.2.1"
 epoll = "=4.0.1"
 libc = ">=0.2.39"
 log = "=0.4.6"
-vm-memory = ">=0.2.0"
+vm-memory = {version = ">=0.2.0", features = ["integer-atomics"] }
 vmm-sys-util = ">=0.4.0"
 
 [dev-dependencies.vm-memory]

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 81.1,
+  "coverage_score": 86.2,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.2,
+  "coverage_score": 89.4,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 
 //! Implements virtio devices, queues, and transport mechanisms.
-extern crate epoll;
+
 #[macro_use]
 extern crate log;
 extern crate vm_memory;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -156,6 +156,22 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
     pub fn memory(&self) -> &M::M {
         &*self.mem
     }
+
+    /// Returns an iterator that only yields the readable descriptors in the chain.
+    pub fn readable(self) -> DescriptorChainRwIter<M> {
+        DescriptorChainRwIter {
+            chain: self,
+            writable: false,
+        }
+    }
+
+    /// Returns an iterator that only yields the writable descriptors in the chain.
+    pub fn writable(self) -> DescriptorChainRwIter<M> {
+        DescriptorChainRwIter {
+            chain: self,
+            writable: true,
+        }
+    }
 }
 
 impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
@@ -185,6 +201,34 @@ impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
             self.ttl -= 1;
         }
         Some(curr)
+    }
+}
+
+/// An iterator for readable or writable descriptors.
+pub struct DescriptorChainRwIter<M: GuestAddressSpace> {
+    chain: DescriptorChain<M>,
+    writable: bool,
+}
+
+impl<M: GuestAddressSpace> Iterator for DescriptorChainRwIter<M> {
+    type Item = Descriptor;
+
+    /// Returns the next descriptor in this descriptor chain, if there is one.
+    ///
+    /// Note that this is distinct from the next descriptor chain returned by
+    /// [`AvailIter`](struct.AvailIter.html), which is the head of the next
+    /// _available_ descriptor chain.
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.chain.next() {
+                Some(v) => {
+                    if v.is_write_only() == self.writable {
+                        return Some(v);
+                    }
+                }
+                None => return None,
+            }
+        }
     }
 }
 
@@ -890,6 +934,69 @@ pub(crate) mod tests {
             c.next().unwrap();
             assert!(!c.has_next());
             assert!(c.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_descriptor_and_iterator() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = VirtQueue::new(GuestAddress(0), m, 16);
+
+        let mut q = vq.create_queue(m);
+
+        // q is currently valid
+        assert!(q.is_valid());
+
+        for j in 0..7 {
+            vq.dtable(j).set(
+                0x1000 * (j + 1) as u64,
+                0x1000,
+                VIRTQ_DESC_F_NEXT,
+                (j + 1) as u16,
+            );
+        }
+
+        // the chains are (0, 1), (2, 3, 4) and (5, 6)
+        vq.dtable(1).flags().store(0);
+        vq.dtable(2)
+            .flags()
+            .store(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+        vq.dtable(4).flags().store(VIRTQ_DESC_F_WRITE);
+        vq.dtable(5)
+            .flags()
+            .store(VIRTQ_DESC_F_NEXT | VIRTQ_DESC_F_WRITE);
+        vq.dtable(6).flags().store(0);
+        vq.avail.ring(0).store(0);
+        vq.avail.ring(1).store(2);
+        vq.avail.ring(2).store(5);
+        vq.avail.idx().store(3);
+
+        let mut i = q.iter();
+
+        {
+            let c = i.next().unwrap();
+            let mut iter = c.into_iter();
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_none());
+            assert!(iter.next().is_none());
+        }
+
+        {
+            let c = i.next().unwrap();
+            let mut iter = c.writable();
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_none());
+            assert!(iter.next().is_none());
+        }
+
+        {
+            let c = i.next().unwrap();
+            let mut iter = c.readable();
+            assert!(iter.next().is_some());
+            assert!(iter.next().is_none());
+            assert!(iter.next().is_none());
         }
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -130,6 +130,8 @@ pub struct DescriptorChain<M: GuestAddressSpace> {
 
     /// The current descriptor
     desc: Descriptor,
+    curr_indirect: Option<Box<DescriptorChain<M>>>,
+    is_master: bool,
 }
 
 impl<M: GuestAddressSpace> DescriptorChain<M> {
@@ -153,6 +155,8 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
             queue_size,
             ttl,
             desc,
+            curr_indirect: None,
+            is_master: true,
         };
 
         if chain.is_valid() {
@@ -189,24 +193,20 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
             return Err(Error::InvalidIndirectDescriptor);
         }
 
+        let mem = self.mem.clone();
+        let desc_table = GuestAddress(desc_head);
         // These reads can't fail unless Guest memory is hopelessly broken.
-        let desc: Descriptor = self
-            .mem
-            .get_slice(GuestAddress(desc_head), size_of::<Descriptor>())
-            .map(|s| s.get_ref(0).unwrap().load())
+        let desc: Descriptor = mem
+            .read_obj(desc_table)
             .map_err(|_| Error::GuestMemoryError)?;
-
         let chain = DescriptorChain {
-            mem: self.mem.clone(),
-            desc_table: GuestAddress(desc_head),
+            mem,
+            desc_table,
             queue_size: (desc_len / VIRTQ_DESCRIPTOR_SIZE) as u16,
             ttl: (desc_len / VIRTQ_DESCRIPTOR_SIZE) as u16,
-            desc: Descriptor {
-                addr: desc.addr,
-                len: desc.len,
-                flags: desc.flags,
-                next: desc.next,
-            },
+            desc,
+            curr_indirect: None,
+            is_master: false,
         };
 
         if !chain.is_valid() {
@@ -269,20 +269,59 @@ impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
             return None;
         }
 
-        let curr = self.desc;
-        if !self.has_next() {
-            self.ttl = 0
+        // Special handling for indirect descriptor table
+        if self.is_indirect() {
+            // An indirect descriptor can not refer to another indirect descriptor table
+            if !self.is_master {
+                return None;
+            }
+            if self.curr_indirect.is_none() {
+                let indirect_chain = self.new_from_indirect().ok()?;
+                self.curr_indirect = Some(Box::new(indirect_chain));
+            }
+            // Above code ensures that it's safe to unwrap().
+            let indirect = self.curr_indirect.as_mut().unwrap();
+
+            match indirect.next() {
+                // return the next descriptor from the indirect chain
+                Some(d) => Some(d),
+                // current indirect chain hs reached the end, return to the master chain.
+                None => {
+                    self.curr_indirect = None;
+                    if !self.has_next() {
+                        // the main descriptor has reached the end too.
+                        self.ttl = 0;
+                        None
+                    } else {
+                        // read next descriptor from the main descriptor chain.
+                        let index = self.desc.next;
+                        let offset = index as u64 * VIRTQ_DESCRIPTOR_SIZE as u64;
+                        let addr = self.desc_table.unchecked_add(offset);
+                        let slice = self.mem.get_slice(addr, VIRTQ_DESCRIPTOR_SIZE).ok()?;
+
+                        self.desc = slice.get_ref(0).ok()?.load();
+                        self.ttl -= 1;
+                        self.next()
+                    }
+                }
+            }
         } else {
-            let index = self.desc.next;
-            let desc_table_size = size_of::<Descriptor>() * self.queue_size as usize;
-            let slice = self.mem.get_slice(self.desc_table, desc_table_size).ok()?;
-            self.desc = slice
-                .get_array_ref(0, self.queue_size as usize)
-                .ok()?
-                .load(index as usize);
-            self.ttl -= 1;
+            let curr = self.desc;
+            if !self.has_next() {
+                self.ttl = 0
+            } else {
+                let index = self.desc.next;
+                let desc_table_size = VIRTQ_DESCRIPTOR_SIZE * self.queue_size as usize;
+                let slice = self.mem.get_slice(self.desc_table, desc_table_size).ok()?;
+                self.desc = slice
+                    .get_array_ref(0, self.queue_size as usize)
+                    .ok()?
+                    .load(index as usize);
+                self.ttl -= 1;
+            }
+
+            Some(curr)
         }
-        Some(curr)
     }
 }
 
@@ -913,11 +952,15 @@ pub(crate) mod tests {
         let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let vq = VirtQueue::new(GuestAddress(0), m, 16);
 
-        // create a chain with a descriptor pointing to an indirect table
+        // create a chain with two descriptor pointing to an indirect tables
         let desc = vq.dtable(0);
-        desc.set(0x1000, 0x1000, VIRTQ_DESC_F_INDIRECT, 0);
+        desc.set(0x1000, 0x1000, VIRTQ_DESC_F_INDIRECT | VIRTQ_DESC_F_NEXT, 1);
+        let desc = vq.dtable(1);
+        desc.set(0x2000, 0x1000, VIRTQ_DESC_F_INDIRECT | VIRTQ_DESC_F_NEXT, 2);
+        let desc = vq.dtable(2);
+        desc.set(0x3000, 0x1000, 0, 0);
 
-        let c: DescriptorChain<&GuestMemoryMmap> =
+        let mut c: DescriptorChain<&GuestMemoryMmap> =
             DescriptorChain::checked_new(m, vq.start(), 16, 0).unwrap();
         assert!(c.is_indirect());
 
@@ -929,17 +972,39 @@ pub(crate) mod tests {
         let mut indirect_table = Vec::with_capacity(4 as usize);
         for j in 0..4 {
             let desc = VirtqDesc::new(&dtable, j);
-            desc.set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, (j + 1) as u16);
+            if j < 3 {
+                desc.set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, (j + 1) as u16);
+            } else {
+                desc.set(0x1000, 0x1000, 0, 0 as u16);
+            }
             indirect_table.push(desc);
         }
 
-        // try to iterate through the indirect table descriptors
-        let mut i = c.new_from_indirect().unwrap();
+        let dtable2 = region
+            .get_slice(MemoryRegionAddress(0x2000u64), VirtqDesc::dtable_len(1))
+            .unwrap();
+        let desc2 = VirtqDesc::new(&dtable2, 0);
+        desc2.set(0x8000, 0x1000, 0, 0);
+
+        // try to iterate through the first indirect descriptor chain
         for j in 0..4 {
-            let desc = i.next().unwrap();
-            assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
-            assert_eq!(desc.next, j + 1);
+            let desc = c.next().unwrap();
+            if j < 3 {
+                assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
+                assert_eq!(desc.next, j + 1);
+            }
         }
+
+        // try to iterate through the second indirect descriptor chain
+        let desc = c.next().unwrap();
+        assert_eq!(desc.addr(), GuestAddress(0x8000));
+
+        // back to the main descriptor chain
+        let desc = c.next().unwrap();
+        assert_eq!(desc.addr(), GuestAddress(0x3000));
+
+        assert!(c.next().is_none());
+        assert!(c.next().is_none());
     }
 
     #[test]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -624,12 +624,6 @@ impl<M: GuestAddressSpace> Queue<M> {
         // We are guaranteed to be within the used ring, this write can't fail.
         mem.write_obj(self.next_used.0, used_ring.unchecked_add(2))
             .unwrap();
-        if !self.event_idx_enabled {
-            // Ensure visibility of virtq_used.idx before sending notification to guest
-            // when the EVENT_IDX feature is disabled, otherwise used_event() will ensure
-            // visibility of virtq_used.idx.
-            fence(Ordering::Release);
-        }
 
         Ok(self.next_used.0)
     }


### PR DESCRIPTION
This patch set includes:
1) some minor bugfixes
2) port EVENT_IDX from cloud hypervisor
3) port readable/writable iterator from cloud hypervisor
4) port indirect descriptoer from cloud hypervisor
5) reduce unused dependency on epoll

This is a patch set split out from #13 , and #13 will only includes GuestMemory related changes.