### PR TITLE
Simple initial benchmark and descriptor handling simplifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,20 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 
 [dependencies]
-byteorder = "=1.2.1"
+byteorder = ">=1.2.1"
 libc = ">=0.2.39"
 log = "=0.4.6"
-vm-memory = {version = ">=0.2.0", features = ["integer-atomics"] }
+vm-memory = {version = ">=0.2.2", features = ["integer-atomics"] }
 vmm-sys-util = ">=0.4.0"
 
-[dev-dependencies.vm-memory]
-version = ">=0.2.0"
-features = ["backend-mmap"]
+[dev-dependencies]
+criterion = "0.3.0"
+vm-memory = { version = ">=0.2.2", features = ["backend-mmap", "backend-atomic" ] }
+
+[[bench]]
+name = "main"
+harness = false
+
+[profile.bench]
+lto = true
+codegen-units = 1

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,21 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+extern crate criterion;
+
+mod queue;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use queue::benchmark_queue;
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(200).measurement_time(std::time::Duration::from_secs(20));
+    targets = benchmark_queue
+}
+
+criterion_main! {
+    benches,
+}

--- a/benches/queue/mock.rs
+++ b/benches/queue/mock.rs
@@ -1,0 +1,270 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::marker::PhantomData;
+use std::mem::size_of;
+
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory};
+
+use vm_virtio::Queue;
+
+struct Ref<'a, M, T> {
+    mem: &'a M,
+    addr: GuestAddress,
+    phantom: PhantomData<*const T>,
+}
+
+impl<'a, M: GuestMemory, T: ByteValued> Ref<'a, M, T> {
+    fn new(mem: &'a M, addr: GuestAddress) -> Self {
+        Ref {
+            mem,
+            addr,
+            phantom: PhantomData,
+        }
+    }
+
+    fn load(&self) -> T {
+        self.mem.read_obj(self.addr).unwrap()
+    }
+
+    fn store(&self, val: T) {
+        self.mem.write_obj(val, self.addr).unwrap()
+    }
+}
+
+struct ArrayRef<'a, M, T> {
+    mem: &'a M,
+    addr: GuestAddress,
+    len: usize,
+    phantom: PhantomData<*const T>,
+}
+
+impl<'a, M: GuestMemory, T: ByteValued> ArrayRef<'a, M, T> {
+    fn new(mem: &'a M, addr: GuestAddress, len: usize) -> Self {
+        ArrayRef {
+            mem,
+            addr,
+            len,
+            phantom: PhantomData,
+        }
+    }
+
+    fn ref_at(&self, index: usize) -> Ref<'a, M, T> {
+        // TODO: add better error handling to the mock logic.
+        assert!(index < self.len);
+
+        let addr = self
+            .addr
+            .checked_add((index * size_of::<T>()) as u64)
+            .unwrap();
+        Ref::new(self.mem, addr)
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct Descriptor {
+    pub addr: u64,
+    pub len: u32,
+    pub flags: u16,
+    pub next: u16,
+}
+
+unsafe impl ByteValued for Descriptor {}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct UsedRingElement {
+    pub id: u32,
+    pub len: u32,
+}
+
+unsafe impl ByteValued for UsedRingElement {}
+
+pub struct SplitQueueRing<'a, M, T: ByteValued> {
+    flags: Ref<'a, M, u16>,
+    idx: Ref<'a, M, u16>,
+    ring: ArrayRef<'a, M, T>,
+    // `used_event` for `AvailRing`, `avail_event` for `UsedRing`.
+    event: Ref<'a, M, u16>,
+}
+
+impl<'a, M: GuestMemory, T: ByteValued> SplitQueueRing<'a, M, T> {
+    pub fn new(mem: &'a M, base: GuestAddress, len: u16) -> Self {
+        let event_addr = base
+            .checked_add(4)
+            .and_then(|a| a.checked_add((size_of::<u16>() * len as usize) as u64))
+            .unwrap();
+
+        let split_queue_ring = SplitQueueRing {
+            flags: Ref::new(mem, base),
+            idx: Ref::new(mem, base.checked_add(2).unwrap()),
+            ring: ArrayRef::new(mem, base.checked_add(4).unwrap(), len as usize),
+            event: Ref::new(mem, event_addr),
+        };
+
+        split_queue_ring.flags.store(0);
+        split_queue_ring.idx.store(0);
+        split_queue_ring.event.store(0);
+
+        split_queue_ring
+    }
+}
+
+pub type AvailRing<'a, M> = SplitQueueRing<'a, M, u16>;
+pub type UsedRing<'a, M> = SplitQueueRing<'a, M, UsedRingElement>;
+
+pub struct DescriptorTable<'a, M> {
+    table: ArrayRef<'a, M, Descriptor>,
+    len: u16,
+    free_descriptors: Vec<u16>,
+}
+
+impl<'a, M: GuestMemory> DescriptorTable<'a, M> {
+    pub fn new(mem: &'a M, addr: GuestAddress, len: u16) -> Self {
+        let table = ArrayRef::new(mem, addr, len as usize);
+        let free_descriptors = (0..len).rev().collect();
+
+        DescriptorTable {
+            table,
+            len,
+            free_descriptors,
+        }
+    }
+
+    pub fn load(&self, index: u16) -> Descriptor {
+        self.table.ref_at(index as usize).load()
+    }
+
+    pub fn store(&self, index: u16, value: Descriptor) {
+        self.table.ref_at(index as usize).store(value)
+    }
+
+    pub fn total_size(&self) -> u64 {
+        (self.len as usize * size_of::<Descriptor>()) as u64
+    }
+
+    pub fn build_chain(&mut self, len: u16) -> u16 {
+        let indices = self
+            .free_descriptors
+            .iter()
+            .copied()
+            .rev()
+            .take(usize::from(len))
+            .collect::<Vec<_>>();
+
+        assert_eq!(indices.len(), len as usize);
+
+        for (pos, index_value) in indices.iter().copied().enumerate() {
+            let mut desc = Descriptor::default();
+            // Addresses and lens constant for now.
+            desc.addr = 0x1000;
+            desc.len = 0x1000;
+
+            // It's not the last descriptor in the chain.
+            if pos < indices.len() - 1 {
+                desc.flags = VIRTQ_DESC_F_NEXT;
+                desc.next = indices[pos + 1];
+            } else {
+                desc.flags = 0;
+            }
+            self.store(index_value, desc);
+        }
+
+        indices[0]
+    }
+}
+
+pub struct MockSplitQueue<'a, M> {
+    mem: &'a M,
+    len: u16,
+    desc_table_addr: GuestAddress,
+    desc_table: DescriptorTable<'a, M>,
+    avail_addr: GuestAddress,
+    avail: AvailRing<'a, M>,
+    used_addr: GuestAddress,
+    _used: UsedRing<'a, M>,
+    indirect_addr: GuestAddress,
+}
+
+// Move to a defs module in vm-virtio?
+const VIRTQ_DESC_F_NEXT: u16 = 0x1;
+const VIRTQ_DESC_F_INDIRECT: u16 = 0x4;
+
+impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
+    pub fn new(mem: &'a M, len: u16) -> Self {
+        // Use these hard-coded addresses for now.
+        let desc_table_addr = GuestAddress(0);
+        let avail_addr = GuestAddress(0x1000_0000);
+        let used_addr = GuestAddress(0x2000_0000);
+        let indirect_addr = GuestAddress(0x3000_0000);
+
+        MockSplitQueue {
+            mem,
+            len,
+            desc_table_addr,
+            desc_table: DescriptorTable::new(mem, desc_table_addr, len),
+            avail_addr,
+            avail: AvailRing::new(mem, avail_addr, len),
+            used_addr,
+            _used: UsedRing::new(mem, used_addr, len),
+            indirect_addr,
+        }
+    }
+
+    fn update_avail_idx(&mut self, value: u16) {
+        let avail_idx = self.avail.idx.load();
+        self.avail.ring.ref_at(avail_idx as usize).store(value);
+        self.avail.idx.store(avail_idx.wrapping_add(1));
+    }
+
+    fn alloc_indirect_chain(&mut self, len: u16) -> GuestAddress {
+        // To simplify things for now, we round up the table len as a multiple of 16. When this is
+        // no longer the case, we should make sure the starting address of the descriptor table
+        // we're  creating below is properly aligned.
+
+        let table_len = if len % 16 == 0 {
+            len
+        } else {
+            16 * (len / 16 + 1)
+        };
+
+        let mut table = DescriptorTable::new(self.mem, self.indirect_addr, table_len);
+        let head_decriptor_index = table.build_chain(len);
+        // When building indirect descriptor tables, the descriptor at index 0 is supposed to be
+        // first in the resulting chain. Just making sure our logic actually makes that happen.
+        assert_eq!(head_decriptor_index, 0);
+
+        let table_addr = self.indirect_addr;
+        self.indirect_addr = self.indirect_addr.checked_add(table.total_size()).unwrap();
+        table_addr
+    }
+
+    pub fn add_chain(&mut self, len: u16) {
+        let head_idx = self.desc_table.build_chain(len);
+        self.update_avail_idx(head_idx);
+    }
+
+    pub fn add_indirect_chain(&mut self, len: u16) {
+        let head_idx = self.desc_table.build_chain(1);
+
+        // We just allocate the indirect table and forget about it for now.
+        let indirect_addr = self.alloc_indirect_chain(len);
+
+        let mut desc = self.desc_table.load(head_idx);
+        desc.flags = VIRTQ_DESC_F_INDIRECT;
+        desc.addr = indirect_addr.raw_value();
+        desc.len = u32::from(len) * size_of::<Descriptor>() as u32;
+
+        self.desc_table.store(head_idx, desc);
+        self.update_avail_idx(head_idx);
+    }
+
+    pub fn create_queue<A: GuestAddressSpace>(&self, a: A) -> Queue<A> {
+        let mut q = Queue::new(a, self.len);
+        q.desc_table = self.desc_table_addr;
+        q.avail_ring = self.avail_addr;
+        q.used_ring = self.used_addr;
+        q
+    }
+}

--- a/benches/queue/mod.rs
+++ b/benches/queue/mod.rs
@@ -1,0 +1,93 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+mod mock;
+
+use criterion::{black_box, BatchSize, Criterion};
+use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vm_virtio::Queue;
+
+use mock::MockSplitQueue;
+
+pub fn benchmark_queue(c: &mut Criterion) {
+    fn walk_queue<A: GuestAddressSpace>(q: &mut Queue<A>) -> (usize, usize) {
+        let mut num_chains = 0;
+        let mut num_descriptors = 0;
+
+        q.iter().for_each(|chain| {
+            num_chains += 1;
+            chain.for_each(|_| num_descriptors += 1);
+        });
+
+        (num_chains, num_descriptors)
+    }
+
+    fn bench_queue<A, S, R>(c: &mut Criterion, bench_name: &str, setup: S, mut routine: R)
+    where
+        A: GuestAddressSpace,
+        S: FnMut() -> Queue<A> + Clone,
+        R: FnMut(Queue<A>),
+    {
+        c.bench_function(bench_name, move |b| {
+            b.iter_batched(
+                setup.clone(),
+                |q| black_box(routine(q)),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0x0), 0x1_0000_0000)]).unwrap();
+
+    let queue_with_chains = |num_chains, len, indirect| {
+        let mut mq = MockSplitQueue::new(&mem, 256);
+        for _ in 0..num_chains {
+            if indirect {
+                mq.add_indirect_chain(len);
+            } else {
+                mq.add_chain(len);
+            }
+        }
+        mq.create_queue(GuestMemoryAtomic::new(mem.clone()))
+    };
+
+    let empty_queue = || {
+        let mq = MockSplitQueue::new(&mem, 256);
+        mq.create_queue(GuestMemoryAtomic::new(mem.clone()))
+    };
+
+    for indirect in [false, true].iter().copied() {
+        bench_queue(
+            c,
+            &format!("single chain (indirect={})", indirect),
+            || queue_with_chains(1, 128, indirect),
+            |mut q| {
+                let (num_chains, num_descriptors) = walk_queue(&mut q);
+                assert_eq!(num_chains, 1);
+                assert_eq!(num_descriptors, 128);
+            },
+        );
+
+        bench_queue(
+            c,
+            &format!("multiple chains (indirect={})", indirect),
+            || queue_with_chains(128, 1, indirect),
+            |mut q| {
+                let (num_chains, num_descriptors) = walk_queue(&mut q);
+                assert_eq!(num_chains, 128);
+                assert_eq!(num_descriptors, 128);
+            },
+        );
+    }
+
+    bench_queue(
+        c,
+        "add used",
+        || empty_queue(),
+        |mut q| {
+            for _ in 0..128 {
+                q.add_used(123, 0x1000).unwrap();
+            }
+        },
+    );
+}

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 89.8,
+  "coverage_score": 87.6,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Hi all! This PR proposes two additions. The first is a `criterion`-based benchmark that mainly exercises descriptor chain iteration (for now :D). That commit is also adding a bunch of functionality that mocks and helps populate `Queue` contents. I've later realized we also had something like that as part of the unit test functionality; going forward, it would be great to unify the auxiliary logic. The benchmark can be started using something like `cargo bench --bench main`.

The second commit proposes some simplifications related to descriptor chain handling, mostly by unifying the handling of descriptors from the initial and indirect tables. Other changes include:
- `DescriptorChain::has_next` has been removed, as its semantics were a bit unclear and didn't seem very useful (it can return `true`, but `next()` may still result in `None` due to other errors).
- `DescriptorChain::is_indirect` now returns true only after an indirect descriptor has been effectively parsed (via `next()`), and the chain starts using the indirect table. Do ppl think this method is actually useful? (in any of its incarnations)
- I removed the `DescriptorChain::is_valid` method. The `self.desc.next < self.queue_size` check is already done in other parts of the code, while the  `checked_offset` validation is not very useful since it only validates the address of the byte past the descriptor, but not the range in-between. The `GuestMemory` implementation will validate accesses anyway before performing them.

Looking forward to any reviews/comments!
