### PR TITLE
Implement Queue::index() and Queue::has_next()

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.2,
+  "coverage_score": 85.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 89.4,
+  "coverage_score": 89.5,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Implement Queue::index() to fix #20 and fix a bug in getting the has_next flag.