### PR TITLE
Add myself to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add the list of code owners here (using their GitHub username)
-* gatekeeper-PullAssigner
+* @alexandruag @jiangliu @slp


### PR DESCRIPTION
Add myself (@slp in GitHub) to CODEOWNERS, to be automatically
assigned as code reviewer.

Signed-off-by: Sergio Lopez <slp@redhat.com>