### PR TITLE
Add setter/getter for Queue::next_avail and derive Clone for DescriptorChain

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -707,6 +707,16 @@ impl<M: GuestAddressSpace> Queue<M> {
     pub fn go_to_previous_position(&mut self) {
         self.next_avail -= Wrapping(1);
     }
+
+    /// Returns the index for the next descriptor in the available ring.
+    pub fn next_avail(&self) -> u16 {
+        self.next_avail.0
+    }
+
+    /// Sets the index for the next descriptor in the available ring.
+    pub fn set_next_avail(&mut self, next_avail: u16) {
+        self.next_avail = Wrapping(next_avail);
+    }
 }
 
 #[cfg(test)]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -148,6 +148,7 @@ impl Descriptor {
 unsafe impl ByteValued for Descriptor {}
 
 /// A virtio descriptor chain.
+#[derive(Clone)]
 pub struct DescriptorChain<M: GuestAddressSpace> {
     mem: M::T,
     desc_table: GuestAddress,


### PR DESCRIPTION
Add setter/getter for `Queue::next_avail` and derive Clone for `DescriptorChain`. These changes enable crates such as `vhost-user-backend` and `vhost-user-fs` to start using this crate.