### PR TITLE
build: Relax dependency on log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 byteorder = ">=1.2.1"
 libc = ">=0.2.39"
-log = "=0.4.6"
+log = ">=0.4.6"
 vm-memory = ">=0.3.0"
 vmm-sys-util = ">=0.4.0"
 


### PR DESCRIPTION
Replace the strict =0.4.6 with the more relaxed >=0.4.6 which matches
vhost-user-backend and so then crate can be combined with a repository
that uses a newer version of log such as cloud-hypervisor.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>