### PR TITLE
split Queue into receiver and sender to support multi-thread environment

### DIFF
--- a/benches/queue/mod.rs
+++ b/benches/queue/mod.rs
@@ -5,7 +5,7 @@ mod mock;
 
 use criterion::{black_box, BatchSize, Criterion};
 use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
-use vm_virtio::Queue;
+use vm_virtio::{Queue, QueueSinkerT, QueueSourceT};
 
 use mock::MockSplitQueue;
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 88.8,
+  "coverage_score": 89.2,
   "exclude_path": "",
   "crate_features": "backend-stdio"
 }

--- a/src/block/request.rs
+++ b/src/block/request.rs
@@ -253,7 +253,7 @@ mod tests {
     use vm_memory::{Address, GuestMemoryMmap};
 
     use crate::queue::tests::VirtQueue;
-    use crate::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+    use crate::{QueueSourceT, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
 
     impl PartialEq for Error {
         fn eq(&self, other: &Self) -> bool {

--- a/src/device/mmio.rs
+++ b/src/device/mmio.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::Ordering;
 use vm_memory::{GuestAddress, GuestAddressSpace};
 
 use crate::device::{status, WithDriverSelect};
-use crate::Queue;
+use crate::{Queue, QueueConfigT};
 
 // Required by the Virtio MMIO device register layout at offset 0 from base. Turns out this
 // is actually the ASCII sequence for "virt" (in little endian ordering).

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -17,7 +17,7 @@ use std::result;
 use std::sync::atomic::AtomicU8;
 use std::sync::Arc;
 
-use crate::Queue;
+use crate::{Queue, QueueConfigT};
 
 pub use mmio::VirtioMmioDevice;
 pub use virtio_config::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType};

--- a/src/device/virtio_config.rs
+++ b/src/device/virtio_config.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use vm_memory::GuestAddressSpace;
 
 use crate::device::{VirtioDevice, WithDriverSelect};
-use crate::Queue;
+use crate::{Queue, QueueConfigT};
 
 /// An object that provides a common virtio device configuration representation. It is not part
 /// of the main `vm-virtio` set of interfaces, but rather can be used as a helper object in

--- a/src/queue/config.rs
+++ b/src/queue/config.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use vm_memory::GuestAddress;
+use vm_memory::{GuestAddress, GuestAddressSpace};
+
+use super::{QueueSinker, QueueSource};
 
 /// Trait to configure virtio queues.
 pub trait QueueConfigT {
@@ -54,4 +56,108 @@ pub trait QueueConfigT {
 
     /// Check if the virtio queue configuration is valid.
     fn is_valid(&self) -> bool;
+}
+
+/// A `QueueConfigT` implementation for split queue source and sinker.
+#[derive(Clone)]
+pub struct QueueConfig<M: GuestAddressSpace> {
+    max_size: u16,
+    source: QueueSource<M>,
+    sinker: QueueSinker<M>,
+}
+
+impl<M: GuestAddressSpace> QueueConfig<M> {
+    /// Create a new `QueueConfig` instance.
+    pub fn new(max_size: u16, source: QueueSource<M>, sinker: QueueSinker<M>) -> Self {
+        QueueConfig {
+            max_size,
+            source,
+            sinker,
+        }
+    }
+
+    /// Clone the queue source.
+    pub fn clone_source(&self) -> QueueSource<M> {
+        self.source.clone()
+    }
+
+    /// Clone the queue sinker.
+    pub fn clone_sinker(&self) -> QueueSinker<M> {
+        self.sinker.clone()
+    }
+}
+
+impl<M: GuestAddressSpace> QueueConfigT for QueueConfig<M> {
+    fn max_size(&self) -> u16 {
+        self.max_size
+    }
+
+    fn actual_size(&self) -> u16 {
+        self.source.0.lock().unwrap().actual_size()
+    }
+
+    fn queue_size(&self) -> u16 {
+        self.source.0.lock().unwrap().queue_size()
+    }
+
+    fn set_queue_size(&mut self, size: u16) {
+        self.source.0.lock().unwrap().set_queue_size(size);
+        self.sinker.0.lock().unwrap().set_queue_size(size);
+    }
+
+    fn desc_table_address(&self) -> GuestAddress {
+        self.source.0.lock().unwrap().desc_table_address()
+    }
+
+    fn set_desc_table_address(&mut self, addr: GuestAddress) {
+        self.source.0.lock().unwrap().set_desc_table_address(addr);
+        self.sinker.0.lock().unwrap().set_desc_table_address(addr);
+    }
+
+    fn avail_ring_address(&self) -> GuestAddress {
+        self.source.0.lock().unwrap().avail_ring_address()
+    }
+
+    fn set_avail_ring_address(&mut self, addr: GuestAddress) {
+        self.source.0.lock().unwrap().set_avail_ring_address(addr);
+        self.sinker.0.lock().unwrap().set_avail_ring_address(addr);
+    }
+
+    fn used_ring_address(&self) -> GuestAddress {
+        self.sinker.0.lock().unwrap().used_ring_address()
+    }
+
+    fn set_used_ring_address(&mut self, addr: GuestAddress) {
+        self.source.0.lock().unwrap().set_used_ring_address(addr);
+        self.sinker.0.lock().unwrap().set_used_ring_address(addr);
+    }
+
+    fn event_idx(&self) -> bool {
+        self.source.0.lock().unwrap().event_idx()
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        self.source.0.lock().unwrap().set_event_idx(enabled);
+        self.sinker.0.lock().unwrap().set_event_idx(enabled)
+    }
+
+    fn ready(&self) -> bool {
+        self.source.0.lock().unwrap().ready()
+    }
+
+    fn set_ready(&mut self, ready: bool) {
+        self.source.0.lock().unwrap().set_ready(ready);
+        self.sinker.0.lock().unwrap().set_ready(ready);
+    }
+
+    fn reset(&mut self) {
+        self.source.0.lock().unwrap().reset();
+        self.sinker.0.lock().unwrap().reset();
+    }
+
+    fn is_valid(&self) -> bool {
+        let source_valid = self.source.0.lock().unwrap().is_valid();
+
+        source_valid && self.sinker.0.lock().unwrap().is_valid()
+    }
 }

--- a/src/queue/config.rs
+++ b/src/queue/config.rs
@@ -1,0 +1,57 @@
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use vm_memory::GuestAddress;
+
+/// Trait to configure virtio queues.
+pub trait QueueConfigT {
+    /// Gets the virtio queue maximum size.
+    fn max_size(&self) -> u16;
+
+    /// Return the actual size of the queue, as the driver may not set up a
+    /// queue as big as the device allows.
+    fn actual_size(&self) -> u16;
+
+    /// Get the actual size of the queue.
+    fn queue_size(&self) -> u16;
+
+    /// Set the actual size of the queue.
+    fn set_queue_size(&mut self, size: u16);
+
+    /// Get the address for the descriptor table.
+    fn desc_table_address(&self) -> GuestAddress;
+
+    /// Set the address for the descriptor table.
+    fn set_desc_table_address(&mut self, addr: GuestAddress);
+
+    /// Get the address for the available ring of split queue.
+    fn avail_ring_address(&self) -> GuestAddress;
+
+    /// Set the address for the available ring of split queue.
+    fn set_avail_ring_address(&mut self, addr: GuestAddress);
+
+    /// Get the address for the used ring of split queue.
+    fn used_ring_address(&self) -> GuestAddress;
+
+    /// Set the address for the used ring of split queue.
+    fn set_used_ring_address(&mut self, addr: GuestAddress);
+
+    /// Returns whether the VIRTIO_F_RING_EVENT_IDX feature has been enabled.
+    fn event_idx(&self) -> bool;
+
+    /// Enable/disable the VIRTIO_F_RING_EVENT_IDX feature.
+    fn set_event_idx(&mut self, enabled: bool);
+
+    /// Returns the ready flag for the queue.
+    fn ready(&self) -> bool;
+
+    /// Setup the queue to start processing requests.
+    fn set_ready(&mut self, ready: bool);
+
+    /// Reset the queue to a state that is acceptable for a device reset
+    fn reset(&mut self);
+
+    /// Check if the virtio queue configuration is valid.
+    fn is_valid(&self) -> bool;
+}

--- a/src/queue/descriptor.rs
+++ b/src/queue/descriptor.rs
@@ -1,0 +1,125 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// Copyright © 2019 Intel Corporation
+//
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use vm_memory::{ByteValued, GuestAddress};
+
+use super::{VIRTQ_DESC_F_INDIRECT, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+
+/// A split virtio descriptor to encapsulate a driver data buffer.
+///
+/// The descriptor table refers to the buffers the driver is using for the device. The `addr` is
+/// a physical address, and the buffers can be chained via next. Each descriptor describes a
+/// buffer which is read-only for the device (“device-readable”) or write-only for the device
+/// (“device-writable”), but a chain of descriptors can contain both device-readable and
+/// device-writable buffers.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+pub struct Descriptor {
+    /// Guest physical address of the data buffer.
+    pub(crate) addr: u64,
+
+    /// Length of the data buffer.
+    pub(crate) len: u32,
+
+    /// Data buffer flags, including the next, write, and indirect bits.
+    pub(crate) flags: u16,
+
+    /// Index into the descriptor table of the next descriptor if flags has the next bit set.
+    pub(crate) next: u16,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl Descriptor {
+    /// Return the guest physical address of descriptor buffer.
+    pub fn addr(&self) -> GuestAddress {
+        GuestAddress(self.addr)
+    }
+
+    /// Return the length of descriptor buffer.
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+
+    /// Return the flags for this descriptor, including next, write and indirect bits.
+    pub fn flags(&self) -> u16 {
+        self.flags
+    }
+
+    /// Return the value stored in the `next` field of the descriptor.
+    pub fn next(&self) -> u16 {
+        self.next
+    }
+
+    /// Check whether the `VIRTQ_DESC_F_NEXT` is set for the descriptor.
+    pub fn has_next(&self) -> bool {
+        self.flags() & VIRTQ_DESC_F_NEXT != 0
+    }
+
+    /// Check whether this is an indirect descriptor.
+    pub fn is_indirect(&self) -> bool {
+        // TODO: The are a couple of restrictions in terms of which flags combinations are
+        // actually valid for indirect descriptors. Implement those checks as well somewhere.
+        self.flags() & VIRTQ_DESC_F_INDIRECT != 0
+    }
+
+    /// Checks if the driver designated this as a write only descriptor.
+    ///
+    /// If this is false, this descriptor is read only.
+    /// Write only means the the emulated device can write and the driver can read.
+    pub fn is_write_only(&self) -> bool {
+        self.flags() & VIRTQ_DESC_F_WRITE != 0
+    }
+}
+
+unsafe impl ByteValued for Descriptor {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vm_memory::Address;
+
+    macro_rules! offset_of {
+        ($ty:ty, $field:ident) => {
+            unsafe { &(*(0 as *const $ty)).$field as *const _ as usize }
+        };
+    }
+
+    #[test]
+    fn test_offset() {
+        assert_eq!(offset_of!(Descriptor, addr), 0);
+        assert_eq!(offset_of!(Descriptor, len), 8);
+        assert_eq!(offset_of!(Descriptor, flags), 12);
+        assert_eq!(offset_of!(Descriptor, next), 14);
+    }
+
+    #[test]
+    fn test_new_descriptor() {
+        let mut desc = Descriptor {
+            addr: 0x1000,
+            len: 0x2000,
+            flags: VIRTQ_DESC_F_WRITE | VIRTQ_DESC_F_NEXT,
+            next: 1,
+        };
+
+        assert_eq!(desc.addr().raw_value(), 0x1000);
+        assert_eq!(desc.len(), 0x2000);
+        assert_eq!(desc.next(), 1);
+        assert_eq!(desc.has_next(), true);
+        assert_eq!(desc.is_write_only(), true);
+        assert_eq!(desc.is_indirect(), false);
+
+        desc.flags = VIRTQ_DESC_F_INDIRECT;
+        assert_eq!(desc.has_next(), false);
+        assert_eq!(desc.is_write_only(), false);
+        assert_eq!(desc.is_indirect(), true);
+    }
+}

--- a/src/queue/descriptor_chain.rs
+++ b/src/queue/descriptor_chain.rs
@@ -1,0 +1,368 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// Copyright © 2019 Intel Corporation
+//
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use std::mem::size_of;
+
+use vm_memory::{Address, Bytes, GuestAddress, GuestAddressSpace};
+
+use super::{Descriptor, Error, VIRTQ_DESCRIPTOR_SIZE};
+
+/// A virtio descriptor chain.
+#[derive(Clone)]
+pub struct DescriptorChain<M: GuestAddressSpace> {
+    mem: M::T,
+    desc_table: GuestAddress,
+    queue_size: u16,
+    head_index: u16,
+    next_index: u16,
+    ttl: u16,
+    pub(crate) is_indirect: bool,
+}
+
+impl<M: GuestAddressSpace> DescriptorChain<M> {
+    fn with_ttl(
+        mem: M::T,
+        desc_table: GuestAddress,
+        queue_size: u16,
+        ttl: u16,
+        head_index: u16,
+    ) -> Self {
+        DescriptorChain {
+            mem,
+            desc_table,
+            queue_size,
+            head_index,
+            next_index: head_index,
+            ttl,
+            is_indirect: false,
+        }
+    }
+
+    /// Create a new `DescriptorChain` instance.
+    pub fn new(mem: M::T, desc_table: GuestAddress, queue_size: u16, head_index: u16) -> Self {
+        Self::with_ttl(mem, desc_table, queue_size, queue_size, head_index)
+    }
+
+    /// Get the descriptor index of the chain header
+    pub fn head_index(&self) -> u16 {
+        self.head_index
+    }
+
+    /// Return a `GuestMemory` object that can be used to access the buffers
+    /// pointed to by the descriptor chain.
+    pub fn memory(&self) -> &M::M {
+        &*self.mem
+    }
+
+    /// Returns an iterator that only yields the readable descriptors in the chain.
+    pub fn readable(self) -> DescriptorChainRwIter<M> {
+        DescriptorChainRwIter {
+            chain: self,
+            writable: false,
+        }
+    }
+
+    /// Returns an iterator that only yields the writable descriptors in the chain.
+    pub fn writable(self) -> DescriptorChainRwIter<M> {
+        DescriptorChainRwIter {
+            chain: self,
+            writable: true,
+        }
+    }
+
+    // Alters the internal state of the `DescriptorChain` to switch iterating over an
+    // indirect descriptor table defined by `desc`.
+    fn process_indirect_descriptor(&mut self, desc: Descriptor) -> Result<(), Error> {
+        if self.is_indirect {
+            return Err(Error::InvalidIndirectDescriptor);
+        }
+
+        let table_len = (desc.len() as usize) / VIRTQ_DESCRIPTOR_SIZE;
+        // Check the target indirect descriptor table is correctly aligned.
+        if desc.addr().raw_value() & (VIRTQ_DESCRIPTOR_SIZE as u64 - 1) != 0
+            || (desc.len() as usize) & (VIRTQ_DESCRIPTOR_SIZE - 1) != 0
+            || table_len > usize::from(std::u16::MAX)
+        {
+            return Err(Error::InvalidIndirectDescriptorTable);
+        }
+
+        self.desc_table = desc.addr();
+        self.queue_size = table_len as u16;
+        self.next_index = 0;
+        self.ttl = self.queue_size;
+        self.is_indirect = true;
+
+        Ok(())
+    }
+}
+
+impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
+    type Item = Descriptor;
+
+    /// Returns the next descriptor in this descriptor chain, if there is one.
+    ///
+    /// Note that this is distinct from the next descriptor chain returned by
+    /// [`AvailIter`](struct.AvailIter.html), which is the head of the next
+    /// _available_ descriptor chain.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ttl == 0 || self.next_index >= self.queue_size {
+            return None;
+        }
+
+        // It's ok to use `unchecked_add` here because we previously verify the index does not
+        // exceed the queue size, and the descriptor table location is expected to have been
+        // validate before (for example, before activating a device). Moreover, this cannot
+        // lead to unsafety because the actual memory accesses are always checked.
+        let desc_addr = self
+            .desc_table
+            .unchecked_add(self.next_index as u64 * size_of::<Descriptor>() as u64);
+
+        let desc = self.mem.read_obj::<Descriptor>(desc_addr).ok()?;
+
+        if desc.is_indirect() {
+            self.process_indirect_descriptor(desc).ok()?;
+            return self.next();
+        }
+
+        if desc.has_next() {
+            self.next_index = desc.next();
+            // It's ok to decrement `self.ttl` here because we check at the start of the method
+            // that it's greater than 0.
+            self.ttl -= 1;
+        } else {
+            self.ttl = 0;
+        }
+
+        Some(desc)
+    }
+}
+
+/// An iterator for readable or writable descriptors.
+pub struct DescriptorChainRwIter<M: GuestAddressSpace> {
+    chain: DescriptorChain<M>,
+    writable: bool,
+}
+
+impl<M: GuestAddressSpace> Iterator for DescriptorChainRwIter<M> {
+    type Item = Descriptor;
+
+    /// Returns the next descriptor in this descriptor chain, if there is one.
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.chain.next() {
+                Some(v) => {
+                    if v.is_write_only() == self.writable {
+                        return Some(v);
+                    }
+                }
+                None => return None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{VirtQueue, VirtqDesc};
+    use super::super::{VIRTQ_DESC_F_INDIRECT, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+    use super::*;
+
+    use std::ops::Deref;
+    use std::sync::Arc;
+    use vm_memory::{GuestMemory, GuestMemoryMmap, GuestMemoryRegion, MemoryRegionAddress};
+
+    #[test]
+    fn test_checked_new_descriptor_chain() {
+        let m = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap());
+        let vq = VirtQueue::new(GuestAddress(0), &m, 16);
+
+        assert!(vq.end().0 < 0x1000);
+
+        // index >= queue_size
+        assert!(
+            DescriptorChain::<Arc<GuestMemoryMmap>>::new(m.clone(), vq.start(), 16, 16)
+                .next()
+                .is_none()
+        );
+
+        // desc_table address is way off
+        assert!(DescriptorChain::<Arc<GuestMemoryMmap>>::new(
+            m.clone(),
+            GuestAddress(0x00ff_ffff_ffff),
+            16,
+            0
+        )
+        .next()
+        .is_none());
+
+        {
+            // the first desc has a normal len, and the next_descriptor flag is set
+            vq.dtable(0).addr().store(0x1000);
+            vq.dtable(0).len().store(0x1000);
+            vq.dtable(0).flags().store(VIRTQ_DESC_F_NEXT);
+            //..but the the index of the next descriptor is too large
+            vq.dtable(0).next().store(16);
+
+            let mut c = DescriptorChain::<Arc<GuestMemoryMmap>>::new(m.clone(), vq.start(), 16, 0);
+            c.next().unwrap();
+            assert!(c.next().is_none());
+        }
+
+        // finally, let's test an ok chain
+        {
+            vq.dtable(0).next().store(1);
+            vq.dtable(1).set(0x2000, 0x1000, 0, 0);
+
+            let mut c = DescriptorChain::<Arc<GuestMemoryMmap>>::new(m.clone(), vq.start(), 16, 0);
+
+            assert_eq!(
+                c.memory() as *const GuestMemoryMmap,
+                m.deref() as *const GuestMemoryMmap
+            );
+            assert_eq!(c.desc_table, vq.dtable_start());
+            assert_eq!(c.queue_size, 16);
+            assert_eq!(c.ttl, c.queue_size);
+            let desc = c.next().unwrap();
+            assert_eq!(desc.addr(), GuestAddress(0x1000));
+            assert_eq!(desc.len(), 0x1000);
+            assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
+            assert_eq!(desc.next(), 1);
+
+            assert!(c.next().is_some());
+            assert!(c.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_new_from_indirect_descriptor() {
+        let m = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap());
+        let vq = VirtQueue::new(GuestAddress(0), &m, 16);
+
+        // create a chain with two descriptor pointing to an indirect tables
+        let desc = vq.dtable(0);
+        desc.set(0x1000, 0x1000, VIRTQ_DESC_F_INDIRECT | VIRTQ_DESC_F_NEXT, 1);
+        let desc = vq.dtable(1);
+        desc.set(0x2000, 0x1000, VIRTQ_DESC_F_INDIRECT | VIRTQ_DESC_F_NEXT, 2);
+        let desc = vq.dtable(2);
+        desc.set(0x3000, 0x1000, 0, 0);
+
+        let mut c: DescriptorChain<Arc<GuestMemoryMmap>> =
+            DescriptorChain::new(m.clone(), vq.start(), 16, 0);
+
+        // The chain logic hasn't parsed the indirect descriptor yet.
+        assert!(!c.is_indirect);
+
+        let region = m.find_region(GuestAddress(0)).unwrap();
+        let dtable = region
+            .get_slice(MemoryRegionAddress(0x1000u64), VirtqDesc::dtable_len(4))
+            .unwrap();
+        // create an indirect table with 4 chained descriptors
+        let mut indirect_table = Vec::with_capacity(4 as usize);
+        for j in 0..4 {
+            let desc = VirtqDesc::new(&dtable, j);
+            if j < 3 {
+                desc.set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, (j + 1) as u16);
+            } else {
+                desc.set(0x1000, 0x1000, 0, 0 as u16);
+            }
+            indirect_table.push(desc);
+        }
+
+        let dtable2 = region
+            .get_slice(MemoryRegionAddress(0x2000u64), VirtqDesc::dtable_len(1))
+            .unwrap();
+        let desc2 = VirtqDesc::new(&dtable2, 0);
+        desc2.set(0x8000, 0x1000, 0, 0);
+
+        assert_eq!(c.head_index(), 0);
+        // try to iterate through the first indirect descriptor chain
+        for j in 0..4 {
+            let desc = c.next().unwrap();
+            assert!(c.is_indirect);
+            if j < 3 {
+                assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
+                assert_eq!(desc.next(), j + 1);
+            }
+        }
+    }
+
+    #[test]
+    fn test_indirect_descriptor_err() {
+        {
+            let m = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap());
+            let vq = VirtQueue::new(GuestAddress(0), &m, 16);
+
+            // create a chain with a descriptor pointing to an indirect table
+            let desc = vq.dtable(0);
+            desc.set(0x1001, 0x1000, VIRTQ_DESC_F_INDIRECT, 0);
+
+            let mut c: DescriptorChain<Arc<GuestMemoryMmap>> =
+                DescriptorChain::new(m.clone(), vq.start(), 16, 0);
+
+            assert!(c.next().is_none());
+        }
+
+        {
+            let m = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap());
+            let vq = VirtQueue::new(GuestAddress(0), &m, 16);
+
+            // create a chain with a descriptor pointing to an indirect table
+            let desc = vq.dtable(0);
+            desc.set(0x1000, 0x1001, VIRTQ_DESC_F_INDIRECT, 0);
+
+            let mut c: DescriptorChain<Arc<GuestMemoryMmap>> =
+                DescriptorChain::new(m.clone(), vq.start(), 16, 0);
+
+            assert!(c.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_descriptor_chain_readable() {
+        let m = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap());
+        let vq = VirtQueue::new(GuestAddress(0), &m, 16);
+
+        assert!(vq.end().0 < 0x1000);
+
+        vq.dtable(0).set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, 1);
+        vq.dtable(1).set(0x2000, 0x1000, VIRTQ_DESC_F_NEXT, 2);
+        vq.dtable(2).set(0x3000, 0x1000, VIRTQ_DESC_F_WRITE, 0);
+
+        let c: DescriptorChain<Arc<GuestMemoryMmap>> =
+            DescriptorChain::new(m.clone(), vq.start(), 16, 0);
+        let mut readable = c.readable();
+        assert!(readable.next().is_some());
+        assert!(readable.next().is_some());
+        assert!(readable.next().is_none());
+    }
+
+    #[test]
+    fn test_descriptor_chain_writable() {
+        let m = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap());
+        let vq = VirtQueue::new(GuestAddress(0), &m, 16);
+
+        assert!(vq.end().0 < 0x1000);
+
+        vq.dtable(0).set(0x1000, 0x1000, VIRTQ_DESC_F_NEXT, 1);
+        vq.dtable(1).set(0x2000, 0x1000, VIRTQ_DESC_F_NEXT, 2);
+        vq.dtable(2)
+            .set(0x3000, 0x1000, VIRTQ_DESC_F_WRITE | VIRTQ_DESC_F_NEXT, 3);
+        vq.dtable(3).set(0x4000, 0x1000, VIRTQ_DESC_F_WRITE, 0);
+
+        let c: DescriptorChain<Arc<GuestMemoryMmap>> =
+            DescriptorChain::new(m.clone(), vq.start(), 16, 0);
+        let mut writable = c.writable();
+        assert!(writable.next().is_some());
+        assert!(writable.next().is_some());
+        assert!(writable.next().is_none());
+    }
+}

--- a/src/queue/iterator.rs
+++ b/src/queue/iterator.rs
@@ -1,0 +1,78 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// Copyright © 2019 Intel Corporation
+//
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use std::num::Wrapping;
+
+use vm_memory::{Address, Bytes, GuestAddress, GuestAddressSpace};
+
+use super::{DescriptorChain, Queue, VIRTQ_AVAIL_ELEMENT_SIZE, VIRTQ_AVAIL_RING_HEADER_SIZE};
+
+/// Consuming iterator over all available descriptor chain heads in the queue.
+pub struct AvailIter<'b, M: GuestAddressSpace> {
+    pub(crate) mem: M::T,
+    pub(crate) desc_table: GuestAddress,
+    pub(crate) avail_ring: GuestAddress,
+    pub(crate) last_index: Wrapping<u16>,
+    pub(crate) queue_size: u16,
+    pub(crate) next_avail: &'b mut Wrapping<u16>,
+}
+
+impl<'b, M: GuestAddressSpace> AvailIter<'b, M> {
+    /// Create a available descriptor iterator, starting at `idx`.
+    pub fn new(queue: &'b mut Queue<M>, idx: Wrapping<u16>) -> Self {
+        AvailIter {
+            mem: queue.mem.memory(),
+            desc_table: queue.desc_table,
+            avail_ring: queue.avail_ring,
+            last_index: idx,
+            queue_size: queue.actual_size(),
+            next_avail: &mut queue.next_avail,
+        }
+    }
+}
+
+impl<'b, M: GuestAddressSpace> Iterator for AvailIter<'b, M> {
+    type Item = DescriptorChain<M>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if *self.next_avail == self.last_index {
+            return None;
+        }
+
+        // This computation cannot overflow because all the values involved are actually
+        // `u16`s cast to `u64`.
+        let offset = VIRTQ_AVAIL_RING_HEADER_SIZE
+            + (self.next_avail.0 % self.queue_size) as u64 * VIRTQ_AVAIL_ELEMENT_SIZE;
+
+        // The logic in `Queue::is_valid` ensures it's ok to use `unchecked_add` as long
+        // as the index is within bounds. We do not currently enforce that a queue is only used
+        // after checking `is_valid`, but rather expect the device implementations to do so
+        // before activation. The standard also forbids drivers to change queue parameters
+        // while the device is "running". A warp-around cannot lead to unsafe memory accesses
+        // because the memory model performs its own validations.
+        let addr = self.avail_ring.unchecked_add(offset);
+        let head_index: u16 = self
+            .mem
+            .read_obj(addr)
+            .map_err(|_| error!("Failed to read from memory {:x}", addr.raw_value()))
+            .ok()?;
+
+        *self.next_avail += Wrapping(1);
+
+        Some(DescriptorChain::new(
+            self.mem.clone(),
+            self.desc_table,
+            self.queue_size,
+            head_index,
+        ))
+    }
+}

--- a/src/queue/iterator.rs
+++ b/src/queue/iterator.rs
@@ -15,7 +15,8 @@ use std::num::Wrapping;
 use vm_memory::{Address, Bytes, GuestAddress, GuestAddressSpace};
 
 use super::{
-    DescriptorChain, Position, Queue, VIRTQ_AVAIL_ELEMENT_SIZE, VIRTQ_AVAIL_RING_HEADER_SIZE,
+    DescriptorChain, Position, Queue, QueueConfigT, VIRTQ_AVAIL_ELEMENT_SIZE,
+    VIRTQ_AVAIL_RING_HEADER_SIZE,
 };
 
 /// Consuming iterator over all available descriptor chain heads in the queue.

--- a/src/queue/sinker.rs
+++ b/src/queue/sinker.rs
@@ -85,6 +85,37 @@ impl<S: QueueSinkerT> QueueSinkerT for RefCell<S> {
     }
 }
 
+/// A default implementation of [QueueSinkerT](trait.QueueSinkerT.html).
+pub struct QueueSinker<M: GuestAddressSpace>(pub(crate) Arc<Mutex<Queue<M>>>);
+
+impl<M: GuestAddressSpace> Clone for QueueSinker<M> {
+    fn clone(&self) -> Self {
+        QueueSinker(self.0.clone())
+    }
+}
+
+impl<M: GuestAddressSpace> QueueSinkerT for QueueSinker<M> {
+    fn sinker_ready(&self) -> bool {
+        self.0.lock().unwrap().sinker_ready()
+    }
+
+    fn next_used(&self) -> u16 {
+        self.0.lock().unwrap().next_used()
+    }
+
+    fn set_next_used(&mut self, next_used: u16) {
+        self.0.lock().unwrap().set_next_used(next_used)
+    }
+
+    fn add_used(&mut self, head_index: u16, len: u32) -> Result<(), Error> {
+        self.0.lock().unwrap().add_used(head_index, len)
+    }
+
+    fn needs_notification(&mut self) -> Result<bool, Error> {
+        self.0.lock().unwrap().needs_notification()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::tests::VirtQueue;

--- a/src/queue/sinker.rs
+++ b/src/queue/sinker.rs
@@ -1,0 +1,175 @@
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright © 2019 Intel Corporation
+//
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::sync::Mutex;
+
+use super::*;
+
+/// Sink to put used descriptors into virtio queues.
+///
+/// For split-queue, it puts used descriptors into the used ring.
+pub trait QueueSinkerT {
+    /// Check whether the queue sinker is ready to process used descriptors.
+    fn sinker_ready(&self) -> bool;
+
+    /// Returns the index for the next descriptor in the available ring.
+    fn next_used(&self) -> u16;
+
+    /// Sets the index for the next descriptor in the available ring.
+    fn set_next_used(&mut self, next_used: u16);
+
+    /// Puts an available descriptor head into the used ring for use by the guest.
+    fn add_used(&mut self, head_index: u16, len: u32) -> Result<(), Error>;
+
+    /// Check whether a notification to the guest is needed.
+    ///
+    /// Please note this method has side effects: once it returns `true`, it considers the
+    /// driver will actually be notified, remember the associated index in the used ring, and
+    /// won't return `true` again until the driver updates `used_event` and/or the notification
+    /// conditions hold once more.
+    fn needs_notification(&mut self) -> Result<bool, Error>;
+}
+
+impl<S: QueueSinkerT> QueueSinkerT for Arc<Mutex<S>> {
+    fn sinker_ready(&self) -> bool {
+        self.lock().unwrap().sinker_ready()
+    }
+
+    fn next_used(&self) -> u16 {
+        self.lock().unwrap().next_used()
+    }
+
+    fn set_next_used(&mut self, next_used: u16) {
+        self.lock().unwrap().set_next_used(next_used);
+    }
+
+    fn add_used(&mut self, head_index: u16, len: u32) -> Result<(), Error> {
+        self.lock().unwrap().add_used(head_index, len)
+    }
+
+    fn needs_notification(&mut self) -> Result<bool, Error> {
+        self.lock().unwrap().needs_notification()
+    }
+}
+
+impl<S: QueueSinkerT> QueueSinkerT for RefCell<S> {
+    fn sinker_ready(&self) -> bool {
+        self.deref().sinker_ready()
+    }
+
+    fn next_used(&self) -> u16 {
+        self.deref().next_used()
+    }
+
+    fn set_next_used(&mut self, next_used: u16) {
+        self.get_mut().set_next_used(next_used)
+    }
+
+    fn add_used(&mut self, head_index: u16, len: u32) -> Result<(), Error> {
+        self.get_mut().add_used(head_index, len)
+    }
+
+    fn needs_notification(&mut self) -> Result<bool, Error> {
+        self.get_mut().needs_notification()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::VirtQueue;
+    use super::*;
+    use vm_memory::GuestMemoryMmap;
+
+    macro_rules! offset_of {
+        ($ty:ty, $field:ident) => {
+            unsafe { &(*(0 as *const $ty)).$field as *const _ as usize }
+        };
+    }
+
+    #[test]
+    fn test_offset() {
+        assert_eq!(offset_of!(VirtqUsedElem, id), 0);
+        assert_eq!(offset_of!(VirtqUsedElem, len), 4);
+    }
+
+    #[test]
+    fn test_add_used() {
+        let m = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = VirtQueue::new(GuestAddress(0), &m, 16);
+
+        let mut q = vq.create_queue(&m);
+        assert_eq!(vq.used.idx().load(), 0);
+
+        //index too large
+        assert!(q.add_used(16, 0x1000).is_err());
+        assert_eq!(vq.used.idx().load(), 0);
+
+        //should be ok
+        q.add_used(1, 0x1000).unwrap();
+        assert_eq!(q.next_used(), 1);
+        assert_eq!(vq.used.idx().load(), 1);
+        let x = vq.used.ring(0).load();
+        assert_eq!(x.id, 1);
+        assert_eq!(x.len, 0x1000);
+    }
+
+    #[test]
+    fn test_sink_is_valid() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let queue = Queue::new(m, 16);
+        let (mut config, _source, _sinker) = queue.split_into_config_source_sinker();
+
+        config.set_used_ring_address(GuestAddress(0x2000));
+        config.set_queue_size(16);
+        config.set_ready(true);
+        assert_eq!(config.is_valid(), true);
+
+        // Available ring not ready
+        config.set_ready(false);
+        assert_eq!(config.is_valid(), false);
+        config.set_ready(true);
+        assert_eq!(config.is_valid(), true);
+
+        // Used ring out of range or not aligned
+        config.set_used_ring_address(GuestAddress(0x20000));
+        assert_eq!(config.is_valid(), false);
+        config.set_used_ring_address(GuestAddress(0x1001));
+        assert_eq!(config.is_valid(), false);
+        config.set_used_ring_address(GuestAddress(0x1000));
+        assert_eq!(config.is_valid(), true);
+
+        // Queue size out of range or not aligned
+        config.set_queue_size(32);
+        assert_eq!(config.is_valid(), false);
+        config.set_queue_size(0);
+        assert_eq!(config.is_valid(), false);
+        config.set_queue_size(15);
+        assert_eq!(config.is_valid(), false);
+        config.set_queue_size(16);
+        assert_eq!(config.is_valid(), true);
+    }
+
+    #[test]
+    fn test_sink_set_next_used() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let queue = Queue::new(m, 16);
+        let (_config, _source, mut sinker) = queue.split_into_config_source_sinker();
+
+        assert_eq!(sinker.next_used(), 0);
+        sinker.set_next_used(1);
+        assert_eq!(sinker.next_used(), 1);
+        sinker.set_next_used(0xffff);
+        assert_eq!(sinker.next_used(), 0xffff);
+    }
+}

--- a/src/queue/source.rs
+++ b/src/queue/source.rs
@@ -1,0 +1,222 @@
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE-BSD-3-Clause file.
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Copyright © 2019 Intel Corporation
+//
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::sync::Mutex;
+
+use vm_memory::GuestAddressSpace;
+
+use super::*;
+
+/// Source to fetch available descriptors from a virtio queue.
+///
+/// For split-queue, it fetches available descriptors from the available ring.
+pub trait QueueSourceT {
+    /// Associated type to access guest memory.
+    type M: GuestAddressSpace;
+
+    /// Associated type of the iterator returned by `iter()`.
+    type I: Iterator<Item = DescriptorChain<Self::M>>;
+
+    /// Check whether the queue source is ready to process available descriptors.
+    fn source_ready(&self) -> bool;
+
+    /// Returns the index for the next descriptor in the available ring.
+    fn next_avail(&self) -> u16;
+
+    /// Sets the index for the next descriptor in the available ring.
+    fn set_next_avail(&mut self, next_avail: u16);
+
+    /// A consuming iterator over all available descriptor chain heads offered by the driver.
+    fn iter(&mut self) -> Result<Self::I, Error>;
+
+    /// Goes back one position in the available descriptor chain offered by the driver.
+    /// Rust does not support bidirectional iterators. This is the only way to revert the effect
+    /// of an iterator increment on the queue.
+    fn go_to_previous_position(&mut self);
+
+    /// Enable notification events from the guest driver. Returns true if one or more descriptors
+    /// can be consumed from the available ring after notifications were enabled (and thus it's
+    /// possible there will be no corresponding notification).
+    // TODO: Turn this into a doc comment/example.
+    // With the current implementation, a common way of consuming entries from the available ring
+    // while also leveraging notification suppression is to use a loop, for example:
+    //
+    // loop {
+    //     // We have to explicitly disable notifications if `VIRTIO_F_EVENT_IDX` has not been
+    //     // negotiated.
+    //     self.disable_notification()?;
+    //
+    //     for chain in self.iter()? {
+    //         // Do something with each chain ...
+    //         // Let's assume we process all available chains here.
+    //     }
+    //
+    //     // If `enable_notification` returns `true`, the driver has added more entries to the
+    //     // available ring.
+    //     if !self.enable_notification()? {
+    //         break;
+    //     }
+    // }
+    fn enable_notification(&mut self) -> Result<bool, Error>;
+
+    /// Disable notification events from the guest driver.
+    fn disable_notification(&mut self) -> Result<(), Error>;
+}
+
+impl<S: QueueSourceT> QueueSourceT for Arc<Mutex<S>> {
+    type M = <S as QueueSourceT>::M;
+    type I = <S as QueueSourceT>::I;
+
+    fn source_ready(&self) -> bool {
+        self.lock().unwrap().source_ready()
+    }
+
+    fn next_avail(&self) -> u16 {
+        self.lock().unwrap().next_avail()
+    }
+
+    fn set_next_avail(&mut self, next_avail: u16) {
+        self.lock().unwrap().set_next_avail(next_avail)
+    }
+
+    fn iter(&mut self) -> Result<Self::I, Error> {
+        self.lock().unwrap().iter()
+    }
+
+    fn go_to_previous_position(&mut self) {
+        panic!("You should go_to_previous_position() from concurrent access!");
+    }
+
+    fn enable_notification(&mut self) -> Result<bool, Error> {
+        self.lock().unwrap().enable_notification()
+    }
+
+    fn disable_notification(&mut self) -> Result<(), Error> {
+        self.lock().unwrap().disable_notification()
+    }
+}
+
+impl<S: QueueSourceT> QueueSourceT for RefCell<S> {
+    type M = <S as QueueSourceT>::M;
+    type I = <S as QueueSourceT>::I;
+
+    fn source_ready(&self) -> bool {
+        self.deref().source_ready()
+    }
+
+    fn next_avail(&self) -> u16 {
+        self.deref().next_avail()
+    }
+
+    fn set_next_avail(&mut self, next_avail: u16) {
+        self.get_mut().set_next_avail(next_avail)
+    }
+
+    fn iter(&mut self) -> Result<Self::I, Error> {
+        self.get_mut().iter()
+    }
+
+    fn go_to_previous_position(&mut self) {
+        self.get_mut().go_to_previous_position()
+    }
+
+    fn enable_notification(&mut self) -> Result<bool, Error> {
+        self.get_mut().enable_notification()
+    }
+
+    fn disable_notification(&mut self) -> Result<(), Error> {
+        self.get_mut().disable_notification()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::QueueConfigT;
+    use super::*;
+    use vm_memory::GuestMemoryMmap;
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_go_to_previous() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let queue = Queue::new(m, 16);
+        let (_config, mut source, _sinker) = queue.split_into_config_source_sinker();
+
+        source.go_to_previous_position();
+    }
+
+    #[test]
+    fn test_source_is_valid() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let queue = Queue::new(m, 16);
+        let (mut config, _queue) = queue.split_into_config_queue();
+
+        config.set_desc_table_address(GuestAddress(0x1000));
+        config.set_used_ring_address(GuestAddress(0x2000));
+        config.set_avail_ring_address(GuestAddress(0x3000));
+        config.set_queue_size(16);
+        config.set_ready(true);
+        assert_eq!(config.is_valid(), true);
+        assert_eq!(config.ready(), true);
+        assert_eq!(config.desc_table_address(), GuestAddress(0x1000));
+        assert_eq!(config.used_ring_address(), GuestAddress(0x2000));
+        assert_eq!(config.avail_ring_address(), GuestAddress(0x3000));
+        assert_eq!(config.event_idx(), false);
+
+        // Available ring not ready
+        config.set_ready(false);
+        assert_eq!(config.is_valid(), false);
+        config.set_ready(true);
+        assert_eq!(config.is_valid(), true);
+
+        // Descriptor table out of range or not aligned
+        config.set_desc_table_address(GuestAddress(0x20000));
+        assert_eq!(config.is_valid(), false);
+        config.set_desc_table_address(GuestAddress(0x1001));
+        assert_eq!(config.is_valid(), false);
+        config.set_desc_table_address(GuestAddress(0x1000));
+        assert_eq!(config.is_valid(), true);
+
+        // Available ring out of range or not aligned
+        config.set_avail_ring_address(GuestAddress(0x20000));
+        assert_eq!(config.is_valid(), false);
+        config.set_avail_ring_address(GuestAddress(0x2001));
+        assert_eq!(config.is_valid(), false);
+        config.set_avail_ring_address(GuestAddress(0x2000));
+        assert_eq!(config.is_valid(), true);
+
+        // Queue size out of range or not aligned
+        config.set_queue_size(32);
+        assert_eq!(config.is_valid(), false);
+        config.set_queue_size(0);
+        assert_eq!(config.is_valid(), false);
+        config.set_queue_size(15);
+        assert_eq!(config.is_valid(), false);
+        config.set_queue_size(16);
+        assert_eq!(config.is_valid(), true);
+    }
+
+    #[test]
+    fn test_source_next_avail() {
+        let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let mut source = Arc::new(Mutex::new(Queue::new(m, 16)));
+
+        assert_eq!(source.next_avail(), 0);
+        source.set_next_avail(1);
+        assert_eq!(source.next_avail(), 1);
+
+        source.set_next_avail(2);
+        assert_eq!(source.next_avail(), 2);
+    }
+}

--- a/src/queue/source.rs
+++ b/src/queue/source.rs
@@ -140,6 +140,48 @@ impl<S: QueueSourceT> QueueSourceT for RefCell<S> {
     }
 }
 
+/// A default implementation of [QueueSourceT](trait.QueueSourceT.html).
+pub struct QueueSource<M: GuestAddressSpace>(pub(crate) Arc<Mutex<Queue<M>>>);
+
+impl<M: GuestAddressSpace> Clone for QueueSource<M> {
+    fn clone(&self) -> Self {
+        QueueSource(self.0.clone())
+    }
+}
+
+impl<M: GuestAddressSpace> QueueSourceT for QueueSource<M> {
+    type M = M;
+    type I = AvailIter<M>;
+
+    fn source_ready(&self) -> bool {
+        self.0.lock().unwrap().source_ready()
+    }
+
+    fn next_avail(&self) -> u16 {
+        self.0.lock().unwrap().next_avail()
+    }
+
+    fn set_next_avail(&mut self, next_avail: u16) {
+        self.0.lock().unwrap().set_next_avail(next_avail)
+    }
+
+    fn iter(&mut self) -> Result<Self::I, Error> {
+        self.0.lock().unwrap().iter()
+    }
+
+    fn go_to_previous_position(&mut self) {
+        panic!("no support of 'go_to_previous_position', it should be removed!");
+    }
+
+    fn enable_notification(&mut self) -> Result<bool, Error> {
+        self.0.lock().unwrap().enable_notification()
+    }
+
+    fn disable_notification(&mut self) -> Result<(), Error> {
+        self.0.lock().unwrap().disable_notification()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::QueueConfigT;

--- a/src/queue/source.rs
+++ b/src/queue/source.rs
@@ -202,13 +202,15 @@ mod tests {
     fn test_source_is_valid() {
         let m = &GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let queue = Queue::new(m, 16);
-        let (mut config, _queue) = queue.split_into_config_queue();
+        let (mut config, queue) = queue.split_into_config_queue();
 
+        assert_eq!(queue.queue_ready(), false);
         config.set_desc_table_address(GuestAddress(0x1000));
         config.set_used_ring_address(GuestAddress(0x2000));
         config.set_avail_ring_address(GuestAddress(0x3000));
         config.set_queue_size(16);
         config.set_ready(true);
+        assert_eq!(queue.queue_ready(), true);
         assert_eq!(config.is_valid(), true);
         assert_eq!(config.ready(), true);
         assert_eq!(config.desc_table_address(), GuestAddress(0x1000));


### PR DESCRIPTION
The virtio queue is duplex comunication channel, it receives available descriptors from the driver and sends used descriptor to the driver. So the queue could be split into a receive endpoint and a sender endpoint.
 
With split queue, the receiver endpoint receives available descriptors from driver by accessing the descriptor table and available ring. It also updates device event suppression status when receiving available descriptors. For the sender endpoint, it puts used descriptors into the used ring. It also queries driver event suppression status when sending used descriptors.
    
For packed queue, it includes a descriptor table, a driver event suppression block and a device event suppression block. So packed queue could be abstracted in the same way as split queue.
    
Current queue implementation is optimzed for single thread environment, there a single thread will receive available descriptors, handle these descriptors and then send those used descriptors in order. This mode will limit the performance of high IO virtio backends, such as virtiofs.
    
So split the queue into receiver and sender. Due to implementation complex, the receiver still only supports single thread environment. For the sender endpoint, both a single thread version and a multiple thread version are provided. For the multi-thread version, it could be send between threads, and the sender and the receiver could work concurrently.

This is also a preparation for support rust async/await and packed queue.