### PR TITLE
RFC: extend Queue to support packed queue

### DIFF
--- a/benches/queue/mock.rs
+++ b/benches/queue/mock.rs
@@ -260,11 +260,11 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
         self.update_avail_idx(head_idx);
     }
 
-    pub fn create_queue<A: GuestAddressSpace>(&self, a: A) -> Queue<A> {
+    pub fn create_queue<A: GuestAddressSpace + Clone>(&self, a: A) -> Queue<A> {
         let mut q = Queue::new(a, self.len);
-        q.desc_table = self.desc_table_addr;
-        q.avail_ring = self.avail_addr;
-        q.used_ring = self.used_addr;
+        q.set_desc_table_address(self.desc_table_addr);
+        q.set_avail_ring_address(self.avail_addr);
+        q.set_used_ring_address(self.used_addr);
         q
     }
 }

--- a/benches/queue/mod.rs
+++ b/benches/queue/mod.rs
@@ -5,7 +5,7 @@ mod mock;
 
 use criterion::{black_box, BatchSize, Criterion};
 use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
-use vm_virtio::Queue;
+use vm_virtio::{DescriptorChainUsed, Queue};
 
 use mock::MockSplitQueue;
 
@@ -86,7 +86,7 @@ pub fn benchmark_queue(c: &mut Criterion) {
         || empty_queue(),
         |mut q| {
             for _ in 0..128 {
-                q.add_used(123, 0x1000).unwrap();
+                q.add_used(123, DescriptorChainUsed::Split(0x1000)).unwrap();
             }
         },
     );

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 88.8,
+  "coverage_score": 90.5,
   "exclude_path": "",
   "crate_features": "backend-stdio"
 }

--- a/src/block/request.rs
+++ b/src/block/request.rs
@@ -231,7 +231,7 @@ impl Request {
 
         let mut desc = desc_chain.next().ok_or(Error::DescriptorChainTooShort)?;
 
-        while desc.has_next() {
+        while desc_chain.has_next(&desc) {
             Request::check_data_desc::<<M>::M>(desc_chain.memory(), desc, request.request_type)?;
 
             request.data.push((desc.addr(), desc.len()));

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -281,7 +281,7 @@ mod tests {
             assert_eq!(d.cfg.device_features & (1 << VIRTIO_F_RING_EVENT_IDX), 0);
 
             for q in d.cfg.queues.iter() {
-                assert_eq!(q.event_idx_enabled, false);
+                assert_eq!(q.event_idx(), false);
             }
 
             // Revert status.
@@ -299,7 +299,7 @@ mod tests {
             assert_eq!(d.cfg.device_status, status);
 
             for q in d.cfg.queues.iter() {
-                assert_eq!(q.event_idx_enabled, true);
+                assert_eq!(q.event_idx(), true);
             }
         }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -122,19 +122,17 @@ impl Descriptor {
     }
 
     /// Return the value stored in the `next` field of the descriptor.
-    pub fn next(&self) -> u16 {
+    fn next(&self) -> u16 {
         self.next
     }
 
     /// Check whether the `VIRTQ_DESC_F_NEXT` is set for the descriptor.
-    pub fn has_next(&self) -> bool {
+    fn has_next(&self) -> bool {
         self.flags() & VIRTQ_DESC_F_NEXT != 0
     }
 
     /// Check whether this is an indirect descriptor.
-    pub fn is_indirect(&self) -> bool {
-        // TODO: The are a couple of restrictions in terms of which flags combinations are
-        // actually valid for indirect descriptors. Implement those checks as well somewhere.
+    fn is_indirect(&self) -> bool {
         self.flags() & VIRTQ_DESC_F_INDIRECT != 0
     }
 
@@ -190,6 +188,11 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
     /// Get the descriptor index of the chain header
     pub fn head_index(&self) -> u16 {
         self.head_index
+    }
+
+    /// Check whether the chain still has next available descriptor.
+    pub fn has_next(&self, desc: &Descriptor) -> bool {
+        desc.has_next()
     }
 
     /// Return a `GuestMemory` object that can be used to access the buffers

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -303,6 +303,15 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
         &*self.mem
     }
 
+    /// Get used descriptor information about the chain.
+    pub fn used_info(&self) -> DescriptorChainUsed {
+        if self.is_packed {
+            DescriptorChainUsed::Packed(self.buffer_id, self.desc_count)
+        } else {
+            DescriptorChainUsed::Split(self.head_index)
+        }
+    }
+
     /// Returns an iterator that only yields the readable descriptors in the chain.
     pub fn readable(self) -> DescriptorChainRwIter<M> {
         DescriptorChainRwIter {
@@ -903,6 +912,14 @@ impl VirtqUsedElem {
 }
 
 unsafe impl ByteValued for VirtqUsedElem {}
+
+/// Information about an used chain.
+pub enum DescriptorChainUsed {
+    /// head_index of used chain for split queue.
+    Split(u16),
+    /// (buffer_id, desc_count) of used chain tuple for packed queue.
+    Packed(u16, u16),
+}
 
 /// Manage the used ring of a split virtio queue and notify the driver on demand.
 pub trait UsedRingT {


### PR DESCRIPTION
Fixes： #6 
This patch set is based on #38 , and aims to implement an PoC by extending current Queue implementation to support Packed Queue. Current design shares most part with split queue, and use flag to control support of packed. 

Currently it only implements basic support of packed to receive available descriptors and send used descriptors. More effort is needed to support device/driver event suppress mechanism.