### PR TITLE
[RFC] Additional queue interface tweaks

### DIFF
--- a/benches/queue/mock.rs
+++ b/benches/queue/mock.rs
@@ -262,9 +262,9 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
 
     pub fn create_queue<A: GuestAddressSpace>(&self, a: A) -> Queue<A> {
         let mut q = Queue::new(a, self.len);
-        q.desc_table = self.desc_table_addr;
-        q.avail_ring = self.avail_addr;
-        q.used_ring = self.used_addr;
+        q.desc_area = self.desc_table_addr;
+        q.driver_area = self.avail_addr;
+        q.device_area = self.used_addr;
         q
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -46,7 +46,7 @@ pub trait VirtioDevice<M: GuestAddressSpace>: Send {
         mem: M,
         interrupt_evt: EventFd,
         status: Arc<AtomicUsize>,
-        queues: Vec<Queue<M>>,
+        queues: QueueConfig,
         queue_evts: Vec<EventFd>,
     ) -> ActivateResult;
 


### PR DESCRIPTION
This PR introduces two sets of changes (besides renaming some fields to correspond with the Virtio 1.1 standard terminology):

- Based on the first iteration and discussions in #27, we add a new `QueueConfig` object that holds the configuration of a queue (sans the memory object), and then `Queue` itself has a new generic type parameter `C` that allows borrowing a `QueueConfig`. For example, we can now remove the `M` dependency from `VirtioDevice` and related abstractions, as well as disconnect the queue configuration from the memory object in general (and recombine them later, or simply create ephemeral `Queue`s that are built using references) when necessary. The extra type parameter can be hidden with aliases; for example `type Queue<M> = vm_virtio::Queue<M, QueueConfig>` is equivalent to the old definition.

- The last commit introduces several tweaks to the `Queue` interface. First, methods that don't necessarily have to return an error (such as the initial incarnation of `needs_notification`) are no longer using `Result` as their return types. I've been experimenting in a couple of settings, and things look clearer without extra error handling. Second, there's a new `Queue::pop_descriptor_chain` method. The `AvailIter` object has to mutably borrow the associated `Queue`, which means we cannot call other `Queue` methods in a block such as `for chain in queue.iter() { /* ... */ queue.add_used(...) }`. The alternative is to pop and process one descriptor chain at a time.

The changes in the RFC are on top of an older master branch. I'll rebase them and update the `VirtioDevice` interfaces as well if things look good so far.
