### PR TITLE
block: Use GuestMemory::checked_range() for validation

### DIFF
--- a/src/block/request.rs
+++ b/src/block/request.rs
@@ -164,11 +164,11 @@ impl Request {
 
         // Check that the address of the status descriptor is valid in guest memory.
         // We will write an u8 status here after executing the request.
-        let _ = mem
-            .checked_offset(desc.addr(), mem::size_of::<u8>())
-            .ok_or_else(|| {
-                Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(desc.addr()))
-            })?;
+        if !mem.check_range(desc.addr(), mem::size_of::<u8>()) {
+            return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
+                desc.addr(),
+            )));
+        }
         Ok(())
     }
 
@@ -187,11 +187,11 @@ impl Request {
         }
 
         // Check that the address of the data descriptor is valid in guest memory.
-        let _ = mem
-            .checked_offset(desc.addr(), desc.len() as usize)
-            .ok_or_else(|| {
-                Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(desc.addr()))
-            })?;
+        if !mem.check_range(desc.addr(), desc.len() as usize) {
+            return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
+                desc.addr(),
+            )));
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Using GuestMemory::checked_offset() will work for the majority of the
time however if the guest chooses to locate the data at the very end of
of the guest memory it will fail as the offset + offset will point to
the next byte (and thus the 0th byte outside the memory.)
GuestMemory::check_range() however takes an offset and length so will
handle this correctly.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>