### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock


### PR DESCRIPTION
This PR adds a `.gitgnore` file that hides the `target` directory and `Cargo.lock` from git.