### PR TITLE
Add some missing trait implementations.

### DIFF
--- a/src/block/stdio_executor.rs
+++ b/src/block/stdio_executor.rs
@@ -103,6 +103,7 @@ pub type Result<T> = result::Result<T, Error>;
 /// let file = File::create("foo.txt").unwrap();
 /// let request_exec = StdIoBackend::new(file, 1 << VIRTIO_BLK_F_FLUSH).unwrap();
 /// ```
+#[derive(Debug)]
 pub struct StdIoBackend<B: Backend> {
     /// The block device backing file.
     inner: B,

--- a/src/device/virtio_config.rs
+++ b/src/device/virtio_config.rs
@@ -20,6 +20,7 @@ use crate::Queue;
 // Adding the `M` generic parameter that's also required by `VirtioDevice` for the time being.
 // The various members have `pub` visibility until we determine whether it makes sense to drop
 // this in favor of adding accessors.
+#[derive(Debug)]
 pub struct VirtioConfig<M: GuestAddressSpace> {
     /// The set of features exposed by the device.
     pub device_features: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 #![deny(missing_docs)]
+#![warn(missing_debug_implementations)]
 
 //! Implements virtio devices, queues, and transport mechanisms.
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -272,6 +272,7 @@ impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
 }
 
 /// An iterator for readable or writable descriptors.
+#[derive(Clone)]
 pub struct DescriptorChainRwIter<M: GuestAddressSpace> {
     chain: DescriptorChain<M>,
     writable: bool,


### PR DESCRIPTION
This PR:

* Derives `Debug` for a few types that were missing them. Also adds a manual implementation for `DescriptorChainRwIter`, because Rust doesn't seem to be able to generate the `M::T: Debug` constraint
* Adds `#![warn(missing_debug_implementations)]`, so we don't regress with missing Debug implementations in the future
* Derive Clone for DescriptorChainRwIter. This is useful in vhost-user-scsi: the virtio-scsi response includes some metadata at the beginning, so it's convenient to write the beginning of the response last. I accomplish this by cloning the DescriptorChainRwIter (or, actually, a higher-level wrapper), skipping forward past the header, writing the body; then using the original DescriptorChainRwIter to write the header.