### PR TITLE
Move virtio-queue constant definitions to a dedicated module

### DIFF
--- a/crates/devices/virtio-blk/src/request.rs
+++ b/crates/devices/virtio-blk/src/request.rs
@@ -248,8 +248,8 @@ mod tests {
 
     use vm_memory::{Address, GuestMemoryMmap};
 
+    use virtio_queue::defs::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
     use virtio_queue::test_utils::VirtQueue;
-    use virtio_queue::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
 
     impl PartialEq for Error {
         fn eq(&self, other: &Self) -> bool {

--- a/crates/virtio-queue/benches/queue/mock.rs
+++ b/crates/virtio-queue/benches/queue/mock.rs
@@ -6,6 +6,7 @@ use std::mem::size_of;
 
 use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory};
 
+use virtio_queue::defs::{VIRTQ_DESC_F_INDIRECT, VIRTQ_DESC_F_NEXT};
 use virtio_queue::Queue;
 
 struct Ref<'a, M, T> {
@@ -188,10 +189,6 @@ pub struct MockSplitQueue<'a, M> {
     _used: UsedRing<'a, M>,
     indirect_addr: GuestAddress,
 }
-
-// Move to a defs module in vm-virtio?
-const VIRTQ_DESC_F_NEXT: u16 = 0x1;
-const VIRTQ_DESC_F_INDIRECT: u16 = 0x4;
 
 impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
     pub fn new(mem: &'a M, len: u16) -> Self {

--- a/crates/virtio-queue/src/defs.rs
+++ b/crates/virtio-queue/src/defs.rs
@@ -1,0 +1,43 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Virtio queue related constant definitions
+
+/// Marks a buffer as continuing via the next field.
+pub const VIRTQ_DESC_F_NEXT: u16 = 0x1;
+
+/// Marks a buffer as device write-only.
+pub const VIRTQ_DESC_F_WRITE: u16 = 0x2;
+
+/// Shows that the buffer contains a list of buffer descriptors.
+pub const VIRTQ_DESC_F_INDIRECT: u16 = 0x4;
+
+/// Used flags
+pub const VIRTQ_USED_F_NO_NOTIFY: u16 = 0x1;
+
+/// This is the size of one element in the used ring.
+pub(crate) const VIRTQ_USED_ELEMENT_SIZE: u64 = 8;
+
+/// Used ring header: flags (u16) + idx (u16)
+pub(crate) const VIRTQ_USED_RING_HEADER_SIZE: u64 = 4;
+
+/// This is the size of the used ring metadata: header + used_event (u16).
+/// The total size of the used ring is:
+/// VIRTQ_USED_RING_HMETA_SIZE + VIRTQ_USED_ELEMENT_SIZE * queue_size
+pub(crate) const VIRTQ_USED_RING_META_SIZE: u64 = VIRTQ_USED_RING_HEADER_SIZE + 2;
+
+/// This is the size of one element in the available ring.
+pub(crate) const VIRTQ_AVAIL_ELEMENT_SIZE: u64 = 2;
+
+/// Avail ring header: flags(u16) + idx(u16)
+pub(crate) const VIRTQ_AVAIL_RING_HEADER_SIZE: u64 = 4;
+
+/// This is the size of the available ring metadata: header + avail_event (u16).
+/// The total size of the available ring is:
+/// VIRTQ_AVAIL_RING_META_SIZE + VIRTQ_AVAIL_ELEMENT_SIZE * queue_size
+pub(crate) const VIRTQ_AVAIL_RING_META_SIZE: u64 = VIRTQ_AVAIL_RING_HEADER_SIZE + 2;
+
+/// The Virtio Spec 1.0 defines the alignment of VirtIO descriptor is 16 bytes,
+/// which fulfills the explicit constraint of GuestMemory::read_obj().
+pub(crate) const VIRTQ_DESCRIPTOR_SIZE: usize = 16;


### PR DESCRIPTION
This is similar to virtio-blk, which already has a dedicated constant definitions module.
My only question is whether to make some of the constants `pub(crate)`, more specifically the ones that define sizes (VIRTQ_AVAIL_ELEMENT_SIZE, etc), as they are only used in virtio-queue crate at the moment.