### PR TITLE
virtio-queue: Handle address translations

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.6,
+  "coverage_score": 90.4,
   "exclude_path": "",
   "crate_features": "virtio-blk/backend-stdio"
 }


### PR DESCRIPTION
For devices with access to data in memory being translated, we add to
the Queue the ability to translate the address stored in the descriptor.

It is very helpful as it performs the translation right after the
untranslated address is read from memory, avoiding any errors from
happening from the consumer's crate perspective. It also allows the
consumer to reduce greatly the amount of duplicated code for applying
the translation in many different places.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>