### PR TITLE
Remove generic type parameter `M` from `QueueState`

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.4,
+  "coverage_score": 83.6,
   "exclude_path": "crates/virtio-queue/src/mock.rs",
   "crate_features": "virtio-blk/backend-stdio"
 }

--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -21,7 +21,6 @@ pub mod mock;
 
 use std::convert::TryFrom;
 use std::fmt::{self, Debug, Display};
-use std::marker::PhantomData;
 use std::mem::size_of;
 use std::num::Wrapping;
 use std::ops::{Deref, DerefMut};
@@ -421,15 +420,15 @@ impl VirtqUsedElem {
 unsafe impl ByteValued for VirtqUsedElem {}
 
 /// Struct to hold an exclusive reference to the underlying `QueueState` object.
-pub enum QueueStateGuard<'a, M: GuestAddressSpace> {
+pub enum QueueStateGuard<'a> {
     /// A reference to a `QueueState` object.
-    StateObject(&'a mut QueueState<M>),
+    StateObject(&'a mut QueueState),
     /// A `MutexGuard` for a `QueueState` object.
-    MutexGuard(MutexGuard<'a, QueueState<M>>),
+    MutexGuard(MutexGuard<'a, QueueState>),
 }
 
-impl<'a, M: GuestAddressSpace> Deref for QueueStateGuard<'a, M> {
-    type Target = QueueState<M>;
+impl<'a> Deref for QueueStateGuard<'a> {
+    type Target = QueueState;
 
     fn deref(&self) -> &Self::Target {
         match self {
@@ -439,7 +438,7 @@ impl<'a, M: GuestAddressSpace> Deref for QueueStateGuard<'a, M> {
     }
 }
 
-impl<'a, M: GuestAddressSpace> DerefMut for QueueStateGuard<'a, M> {
+impl<'a> DerefMut for QueueStateGuard<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             QueueStateGuard::StateObject(v) => v,
@@ -452,12 +451,12 @@ impl<'a, M: GuestAddressSpace> DerefMut for QueueStateGuard<'a, M> {
 ///
 /// To optimize for performance, different implementations of the `QueueStateT` trait may be
 /// provided for single-threaded context and multi-threaded context.
-pub trait QueueStateT<M: GuestAddressSpace> {
+pub trait QueueStateT {
     /// Construct an empty virtio queue state object with the given `max_size`.
     fn new(max_size: u16) -> Self;
 
     /// Check whether the queue configuration is valid.
-    fn is_valid(&self, mem: &M::T) -> bool;
+    fn is_valid<M: GuestMemory>(&self, mem: &M) -> bool;
 
     /// Reset the queue to the initial state.
     fn reset(&mut self);
@@ -466,7 +465,7 @@ pub trait QueueStateT<M: GuestAddressSpace> {
     ///
     /// Logically this method will acquire the underlying lock protecting the `QueueState` Object.
     /// The lock will be released when the returned object gets dropped.
-    fn lock(&mut self) -> QueueStateGuard<'_, M>;
+    fn lock(&mut self) -> QueueStateGuard;
 
     /// Get the maximum size of the virtio queue.
     fn max_size(&self) -> u16;
@@ -505,20 +504,21 @@ pub trait QueueStateT<M: GuestAddressSpace> {
     fn set_event_idx(&mut self, enabled: bool);
 
     /// Read the `idx` field from the available ring.
-    fn avail_idx(&self, mem: &M::T, order: Ordering) -> Result<Wrapping<u16>, Error>;
+    fn avail_idx<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error>;
 
     /// Put a used descriptor head into the used ring.
-    fn add_used(&mut self, mem: &M::T, head_index: u16, len: u32) -> Result<(), Error>;
+    fn add_used<M: GuestMemory>(&mut self, mem: &M, head_index: u16, len: u32)
+        -> Result<(), Error>;
 
     /// Enable notification events from the guest driver.
     ///
     /// Return true if one or more descriptors can be consumed from the available ring after
     /// notifications were enabled (and thus it's possible there will be no corresponding
     /// notification).
-    fn enable_notification(&mut self, mem: &M::T) -> Result<bool, Error>;
+    fn enable_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<bool, Error>;
 
     /// Disable notification events from the guest driver.
-    fn disable_notification(&mut self, mem: &M::T) -> Result<(), Error>;
+    fn disable_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<(), Error>;
 
     /// Check whether a notification to the guest is needed.
     ///
@@ -526,7 +526,7 @@ pub trait QueueStateT<M: GuestAddressSpace> {
     /// driver will actually be notified, remember the associated index in the used ring, and
     /// won't return `true` again until the driver updates `used_event` and/or the notification
     /// conditions hold once more.
-    fn needs_notification(&mut self, mem: &M::T) -> Result<bool, Error>;
+    fn needs_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<bool, Error>;
 
     /// Return the index for the next descriptor in the available ring.
     fn next_avail(&self) -> u16;
@@ -541,7 +541,7 @@ const DEFAULT_USED_RING_ADDR: u64 = 0x0;
 
 /// Struct to maintain information and manipulate state of a virtio queue.
 #[derive(Clone, Debug)]
-pub struct QueueState<M: GuestAddressSpace> {
+pub struct QueueState {
     /// The maximal size in elements offered by the device
     pub max_size: u16,
 
@@ -571,14 +571,16 @@ pub struct QueueState<M: GuestAddressSpace> {
 
     /// Guest physical address of the used ring
     pub used_ring: GuestAddress,
-
-    phantom: PhantomData<M>,
 }
 
-impl<M: GuestAddressSpace> QueueState<M> {
+impl QueueState {
     /// Get a consuming iterator over all available descriptor chain heads offered by the driver.
-    pub fn iter(&mut self, mem: M::T) -> Result<AvailIter<'_, M::T>, Error> {
-        self.avail_idx(&mem, Ordering::Acquire)
+    pub fn iter<M>(&mut self, mem: M) -> Result<AvailIter<'_, M>, Error>
+    where
+        M: Deref,
+        M::Target: GuestMemory + Sized,
+    {
+        self.avail_idx(mem.deref(), Ordering::Acquire)
             .map(move |idx| AvailIter {
                 mem,
                 desc_table: self.desc_table,
@@ -591,7 +593,12 @@ impl<M: GuestAddressSpace> QueueState<M> {
 
     // Helper method that writes `val` to the `avail_event` field of the used ring, using
     // the provided ordering.
-    fn set_avail_event(&self, mem: &M::T, val: u16, order: Ordering) -> Result<(), Error> {
+    fn set_avail_event<M: GuestMemory>(
+        &self,
+        mem: &M,
+        val: u16,
+        order: Ordering,
+    ) -> Result<(), Error> {
         let elem_sz = VIRTQ_USED_ELEMENT_SIZE * u64::from(self.size);
         let offset = VIRTQ_USED_RING_HEADER_SIZE + elem_sz;
         let addr = self.used_ring.unchecked_add(offset);
@@ -600,7 +607,12 @@ impl<M: GuestAddressSpace> QueueState<M> {
     }
 
     // Set the value of the `flags` field of the used ring, applying the specified ordering.
-    fn set_used_flags(&mut self, mem: &M::T, val: u16, order: Ordering) -> Result<(), Error> {
+    fn set_used_flags<M: GuestMemory>(
+        &mut self,
+        mem: &M,
+        val: u16,
+        order: Ordering,
+    ) -> Result<(), Error> {
         mem.store(val, self.used_ring, order)
             .map_err(Error::GuestMemory)
     }
@@ -609,7 +621,7 @@ impl<M: GuestAddressSpace> QueueState<M> {
     //
     // Every access in this method uses `Relaxed` ordering because a fence is added by the caller
     // when appropriate.
-    fn set_notification(&mut self, mem: &M::T, enable: bool) -> Result<(), Error> {
+    fn set_notification<M: GuestMemory>(&mut self, mem: &M, enable: bool) -> Result<(), Error> {
         if enable {
             if self.event_idx_enabled {
                 // We call `set_avail_event` using the `next_avail` value, instead of reading
@@ -638,7 +650,7 @@ impl<M: GuestAddressSpace> QueueState<M> {
     /// Neither of these interrupt suppression methods are reliable, as they are not synchronized
     /// with the device, but they serve as useful optimizations. So we only ensure access to the
     /// virtq_avail.used_event is atomic, but do not need to synchronize with other memory accesses.
-    fn used_event(&self, mem: &M::T, order: Ordering) -> Result<Wrapping<u16>, Error> {
+    fn used_event<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error> {
         // Safe because we have validated the queue and access guest
         // memory through GuestMemory interfaces.
         let elem_sz = u64::from(self.size) * VIRTQ_AVAIL_ELEMENT_SIZE;
@@ -651,7 +663,7 @@ impl<M: GuestAddressSpace> QueueState<M> {
     }
 }
 
-impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
+impl QueueStateT for QueueState {
     fn new(max_size: u16) -> Self {
         QueueState {
             max_size,
@@ -664,11 +676,10 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
             next_used: Wrapping(0),
             event_idx_enabled: false,
             signalled_used: None,
-            phantom: PhantomData,
         }
     }
 
-    fn is_valid(&self, mem: &M::T) -> bool {
+    fn is_valid<M: GuestMemory>(&self, mem: &M) -> bool {
         let queue_size = self.size as u64;
         let desc_table = self.desc_table;
         let desc_table_size = size_of::<Descriptor>() as u64 * queue_size;
@@ -726,7 +737,7 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
         self.event_idx_enabled = false;
     }
 
-    fn lock(&mut self) -> QueueStateGuard<'_, M> {
+    fn lock(&mut self) -> QueueStateGuard {
         QueueStateGuard::StateObject(self)
     }
 
@@ -791,7 +802,7 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
         self.event_idx_enabled = enabled;
     }
 
-    fn avail_idx(&self, mem: &M::T, order: Ordering) -> Result<Wrapping<u16>, Error> {
+    fn avail_idx<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error> {
         let addr = self.avail_ring.unchecked_add(2);
 
         mem.load(addr, order)
@@ -799,7 +810,12 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
             .map_err(Error::GuestMemory)
     }
 
-    fn add_used(&mut self, mem: &M::T, head_index: u16, len: u32) -> Result<(), Error> {
+    fn add_used<M: GuestMemory>(
+        &mut self,
+        mem: &M,
+        head_index: u16,
+        len: u32,
+    ) -> Result<(), Error> {
         if head_index >= self.size {
             error!(
                 "attempted to add out of bounds descriptor to used ring: {}",
@@ -845,7 +861,7 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
     //         break;
     //     }
     // }
-    fn enable_notification(&mut self, mem: &M::T) -> Result<bool, Error> {
+    fn enable_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<bool, Error> {
         self.set_notification(mem, true)?;
         // Ensures the following read is not reordered before any previous write operation.
         fence(Ordering::SeqCst);
@@ -860,11 +876,11 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
             .map(|idx| idx != self.next_avail)
     }
 
-    fn disable_notification(&mut self, mem: &M::T) -> Result<(), Error> {
+    fn disable_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<(), Error> {
         self.set_notification(mem, false)
     }
 
-    fn needs_notification(&mut self, mem: &M::T) -> Result<bool, Error> {
+    fn needs_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<bool, Error> {
         let used_idx = self.next_used;
 
         // Complete all the writes in add_used() before reading the event.
@@ -900,18 +916,18 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueState<M> {
 /// Struct to maintain information and manipulate state of a virtio queue for multi-threaded
 /// context.
 #[derive(Clone, Debug)]
-pub struct QueueStateSync<M: GuestAddressSpace> {
-    state: Arc<Mutex<QueueState<M>>>,
+pub struct QueueStateSync {
+    state: Arc<Mutex<QueueState>>,
 }
 
-impl<M: GuestAddressSpace> QueueStateT<M> for QueueStateSync<M> {
+impl QueueStateT for QueueStateSync {
     fn new(max_size: u16) -> Self {
         QueueStateSync {
             state: Arc::new(Mutex::new(QueueState::new(max_size))),
         }
     }
 
-    fn is_valid(&self, mem: &M::T) -> bool {
+    fn is_valid<M: GuestMemory>(&self, mem: &M) -> bool {
         self.state.lock().unwrap().is_valid(mem)
     }
 
@@ -919,7 +935,7 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueStateSync<M> {
         self.state.lock().unwrap().reset();
     }
 
-    fn lock(&mut self) -> QueueStateGuard<'_, M> {
+    fn lock(&mut self) -> QueueStateGuard {
         QueueStateGuard::MutexGuard(self.state.lock().unwrap())
     }
 
@@ -955,23 +971,28 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueStateSync<M> {
         self.state.lock().unwrap().set_event_idx(enabled);
     }
 
-    fn avail_idx(&self, mem: &M::T, order: Ordering) -> Result<Wrapping<u16>, Error> {
+    fn avail_idx<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error> {
         self.state.lock().unwrap().avail_idx(mem, order)
     }
 
-    fn add_used(&mut self, mem: &M::T, head_index: u16, len: u32) -> Result<(), Error> {
+    fn add_used<M: GuestMemory>(
+        &mut self,
+        mem: &M,
+        head_index: u16,
+        len: u32,
+    ) -> Result<(), Error> {
         self.state.lock().unwrap().add_used(mem, head_index, len)
     }
 
-    fn enable_notification(&mut self, mem: &M::T) -> Result<bool, Error> {
+    fn enable_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<bool, Error> {
         self.state.lock().unwrap().enable_notification(mem)
     }
 
-    fn disable_notification(&mut self, mem: &M::T) -> Result<(), Error> {
+    fn disable_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<(), Error> {
         self.state.lock().unwrap().disable_notification(mem)
     }
 
-    fn needs_notification(&mut self, mem: &M::T) -> Result<bool, Error> {
+    fn needs_notification<M: GuestMemory>(&mut self, mem: &M) -> Result<bool, Error> {
         self.state.lock().unwrap().needs_notification(mem)
     }
 
@@ -986,14 +1007,14 @@ impl<M: GuestAddressSpace> QueueStateT<M> for QueueStateSync<M> {
 
 /// A convenient wrapper struct for a virtio queue, with associated GuestMemory object.
 #[derive(Clone, Debug)]
-pub struct Queue<M: GuestAddressSpace, S: QueueStateT<M> = QueueState<M>> {
+pub struct Queue<M: GuestAddressSpace, S: QueueStateT = QueueState> {
     /// Guest memory object associated with the queue.
     pub mem: M,
     /// Virtio queue state.
     pub state: S,
 }
 
-impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
+impl<M: GuestAddressSpace, S: QueueStateT> Queue<M, S> {
     /// Construct an empty virtio queue with the given `max_size`.
     pub fn new(mem: M, max_size: u16) -> Self {
         Queue {
@@ -1004,7 +1025,7 @@ impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
 
     /// Check whether the queue configuration is valid.
     pub fn is_valid(&self) -> bool {
-        self.state.is_valid(&self.mem.memory())
+        self.state.is_valid(self.mem.memory().deref())
     }
 
     /// Reset the queue to the initial state.
@@ -1016,7 +1037,7 @@ impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
     ///
     /// Logically this method will acquire the underlying lock protecting the `QueueState` Object.
     /// The lock will be released when the returned object gets dropped.
-    pub fn lock(&mut self) -> QueueStateGuard<'_, M> {
+    pub fn lock(&mut self) -> QueueStateGuard {
         self.state.lock()
     }
 
@@ -1074,12 +1095,13 @@ impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
 
     /// Read the `idx` field from the available ring.
     pub fn avail_idx(&self, order: Ordering) -> Result<Wrapping<u16>, Error> {
-        self.state.avail_idx(&self.mem.memory(), order)
+        self.state.avail_idx(self.mem.memory().deref(), order)
     }
 
     /// Put a used descriptor head into the used ring.
     pub fn add_used(&mut self, head_index: u16, len: u32) -> Result<(), Error> {
-        self.state.add_used(&self.mem.memory(), head_index, len)
+        self.state
+            .add_used(self.mem.memory().deref(), head_index, len)
     }
 
     /// Enable notification events from the guest driver.
@@ -1088,12 +1110,12 @@ impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
     /// notifications were enabled (and thus it's possible there will be no corresponding
     /// notification).
     pub fn enable_notification(&mut self) -> Result<bool, Error> {
-        self.state.enable_notification(&self.mem.memory())
+        self.state.enable_notification(self.mem.memory().deref())
     }
 
     /// Disable notification events from the guest driver.
     pub fn disable_notification(&mut self) -> Result<(), Error> {
-        self.state.disable_notification(&self.mem.memory())
+        self.state.disable_notification(self.mem.memory().deref())
     }
 
     /// Check whether a notification to the guest is needed.
@@ -1103,7 +1125,7 @@ impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
     /// won't return `true` again until the driver updates `used_event` and/or the notification
     /// conditions hold once more.
     pub fn needs_notification(&mut self) -> Result<bool, Error> {
-        self.state.needs_notification(&self.mem.memory())
+        self.state.needs_notification(self.mem.memory().deref())
     }
 
     /// Return the index for the next descriptor in the available ring.
@@ -1117,7 +1139,7 @@ impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
     }
 }
 
-impl<M: GuestAddressSpace> Queue<M, QueueState<M>> {
+impl<M: GuestAddressSpace> Queue<M, QueueState> {
     /// A consuming iterator over all available descriptor chain heads offered by the driver.
     pub fn iter(&mut self) -> Result<AvailIter<'_, M::T>, Error> {
         self.state.iter(self.mem.memory())

--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -146,8 +146,8 @@ unsafe impl ByteValued for Descriptor {}
 
 /// A virtio descriptor chain.
 #[derive(Clone, Debug)]
-pub struct DescriptorChain<M: GuestAddressSpace> {
-    mem: M::T,
+pub struct DescriptorChain<M> {
+    mem: M,
     desc_table: GuestAddress,
     queue_size: u16,
     head_index: u16,
@@ -156,9 +156,13 @@ pub struct DescriptorChain<M: GuestAddressSpace> {
     is_indirect: bool,
 }
 
-impl<M: GuestAddressSpace> DescriptorChain<M> {
+impl<M> DescriptorChain<M>
+where
+    M: Deref,
+    M::Target: GuestMemory,
+{
     fn with_ttl(
-        mem: M::T,
+        mem: M,
         desc_table: GuestAddress,
         queue_size: u16,
         ttl: u16,
@@ -176,7 +180,7 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
     }
 
     /// Create a new `DescriptorChain` instance.
-    fn new(mem: M::T, desc_table: GuestAddress, queue_size: u16, head_index: u16) -> Self {
+    fn new(mem: M, desc_table: GuestAddress, queue_size: u16, head_index: u16) -> Self {
         Self::with_ttl(mem, desc_table, queue_size, queue_size, head_index)
     }
 
@@ -187,8 +191,8 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
 
     /// Return a `GuestMemory` object that can be used to access the buffers
     /// pointed to by the descriptor chain.
-    pub fn memory(&self) -> &M::M {
-        &*self.mem
+    pub fn memory(&self) -> &M::Target {
+        self.mem.deref()
     }
 
     /// Returns an iterator that only yields the readable descriptors in the chain.
@@ -237,7 +241,11 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
     }
 }
 
-impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
+impl<M> Iterator for DescriptorChain<M>
+where
+    M: Deref,
+    M::Target: GuestMemory,
+{
     type Item = Descriptor;
 
     /// Returns the next descriptor in this descriptor chain, if there is one.
@@ -282,12 +290,16 @@ impl<M: GuestAddressSpace> Iterator for DescriptorChain<M> {
 
 /// An iterator for readable or writable descriptors.
 #[derive(Clone)]
-pub struct DescriptorChainRwIter<M: GuestAddressSpace> {
+pub struct DescriptorChainRwIter<M> {
     chain: DescriptorChain<M>,
     writable: bool,
 }
 
-impl<M: GuestAddressSpace> Iterator for DescriptorChainRwIter<M> {
+impl<M> Iterator for DescriptorChainRwIter<M>
+where
+    M: Deref,
+    M::Target: GuestMemory,
+{
     type Item = Descriptor;
 
     /// Returns the next descriptor in this descriptor chain, if there is one.
@@ -311,9 +323,9 @@ impl<M: GuestAddressSpace> Iterator for DescriptorChainRwIter<M> {
 
 // We can't derive Debug, because rustc doesn't generate the M::T: Debug
 // constraint
-impl<M: Debug + GuestAddressSpace> Debug for DescriptorChainRwIter<M>
+impl<M> Debug for DescriptorChainRwIter<M>
 where
-    M::T: Debug,
+    M: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DescriptorChainRwIter")
@@ -325,8 +337,8 @@ where
 
 /// Consuming iterator over all available descriptor chain heads in the queue.
 #[derive(Debug)]
-pub struct AvailIter<'b, M: GuestAddressSpace> {
-    mem: M::T,
+pub struct AvailIter<'b, M> {
+    mem: M,
     desc_table: GuestAddress,
     avail_ring: GuestAddress,
     last_index: Wrapping<u16>,
@@ -334,7 +346,7 @@ pub struct AvailIter<'b, M: GuestAddressSpace> {
     next_avail: &'b mut Wrapping<u16>,
 }
 
-impl<'b, M: GuestAddressSpace> AvailIter<'b, M> {
+impl<'b, M> AvailIter<'b, M> {
     /// Goes back one position in the available descriptor chain offered by the driver.
     ///
     /// Rust does not support bidirectional iterators. This is the only way to revert the effect
@@ -347,7 +359,11 @@ impl<'b, M: GuestAddressSpace> AvailIter<'b, M> {
     }
 }
 
-impl<'b, M: GuestAddressSpace> Iterator for AvailIter<'b, M> {
+impl<'b, M> Iterator for AvailIter<'b, M>
+where
+    M: Clone + Deref,
+    M::Target: GuestMemory,
+{
     type Item = DescriptorChain<M>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -561,7 +577,7 @@ pub struct QueueState<M: GuestAddressSpace> {
 
 impl<M: GuestAddressSpace> QueueState<M> {
     /// Get a consuming iterator over all available descriptor chain heads offered by the driver.
-    pub fn iter(&mut self, mem: M::T) -> Result<AvailIter<'_, M>, Error> {
+    pub fn iter(&mut self, mem: M::T) -> Result<AvailIter<'_, M::T>, Error> {
         self.avail_idx(&mem, Ordering::Acquire)
             .map(move |idx| AvailIter {
                 mem,
@@ -1103,7 +1119,7 @@ impl<M: GuestAddressSpace, S: QueueStateT<M>> Queue<M, S> {
 
 impl<M: GuestAddressSpace> Queue<M, QueueState<M>> {
     /// A consuming iterator over all available descriptor chain heads offered by the driver.
-    pub fn iter(&mut self) -> Result<AvailIter<'_, M>, Error> {
+    pub fn iter(&mut self) -> Result<AvailIter<'_, M::T>, Error> {
         self.state.iter(self.mem.memory())
     }
 }

--- a/crates/virtio-queue/src/mock.rs
+++ b/crates/virtio-queue/src/mock.rs
@@ -354,8 +354,8 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
 
     /// Creates a new `Queue`, using the underlying memory regions represented
     /// by the `MockSplitQueue`.
-    pub fn create_queue<A: GuestAddressSpace>(&self, a: A) -> Queue<A, QueueState<A>> {
-        let mut q = Queue::<A, QueueState<A>>::new(a, self.len);
+    pub fn create_queue<A: GuestAddressSpace>(&self, a: A) -> Queue<A, QueueState> {
+        let mut q = Queue::<A, QueueState>::new(a, self.len);
 
         q.state.size = self.len;
         q.state.ready = true;


### PR DESCRIPTION
This PR simplifies the `QueueState` abstraction by removing the generic type parameter `M`, and also relaxes the trait bounds for `AvailIter` and `Descriptor` chain to not depend on `GuestAddressSpace` anymore, as the logic within is only interested in `M` dereferencing to something that implements `GuestMemory` (and not also in the part that it might be one of the associated type of a `GuestAddressSpace` implementation).