### PR TITLE
Update vm-memory requirement from 0.6 to 0.7

### DIFF
--- a/crates/devices/virtio-blk/Cargo.toml
+++ b/crates/devices/virtio-blk/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 backend-stdio = []
 
 [dependencies]
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = ">=0.8.0"
 log = ">=0.4.6"
 virtio-queue = { path = "../../virtio-queue" }
 virtio-device = { path = "../../virtio-device" }
 
 [dev-dependencies]
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }

--- a/crates/virtio-device/Cargo.toml
+++ b/crates/virtio-device/Cargo.toml
@@ -10,9 +10,9 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 
 [dependencies]
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 log = ">=0.4.6"
 virtio-queue = { path = "../virtio-queue" }
 
 [dev-dependencies]
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2018"
 test-utils = []
 
 [dependencies]
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = ">=0.8.0"
 log = ">=0.4.6"
 
 [dev-dependencies]
 criterion = "0.3.0"
-vm-memory = { version = "0.6.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
 
 [[bench]]
 name = "main"


### PR DESCRIPTION
Upgrade to the latest vm-memory v0.7 release.

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>