### PR TITLE
avoid deref_nullptr warnings

### DIFF
--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -20,6 +20,7 @@ log = ">=0.4.6"
 [dev-dependencies]
 criterion = "0.3.0"
 vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+memoffset = "~0"
 
 [[bench]]
 name = "main"

--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -1121,16 +1121,10 @@ impl<M: GuestAddressSpace> Queue<M, QueueState<M>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use memoffset::offset_of;
     use mock::{DescriptorTable, MockSplitQueue};
 
     use vm_memory::{GuestAddress, GuestMemoryMmap};
-
-    /// Extracts the displacement of a field in a struct
-    macro_rules! offset_of {
-        ($ty:ty, $field:ident) => {
-            unsafe { &(*std::ptr::null::<$ty>()).$field as *const _ as usize }
-        };
-    }
 
     #[test]
     pub fn test_offset() {


### PR DESCRIPTION
Compiling vm-virtio causes `deref_nullptr` warnings:

```
warning: dereferencing a null pointer
    --> crates/virtio-queue/src/lib.rs:1164:23
     |
1164 |             unsafe { &(*std::ptr::null::<$ty>()).$field as *const _ as usize }
     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
...
1171 |         assert_eq!(offset_of!(Descriptor, len), 8);
     |                    --------------------------- in this macro invocation
     |
```

The memoffset uses fancier techniques that avoid the warnings.