### PR TITLE
virtio-queue: Publicize DescriptorChain::new()

### DIFF
--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -179,7 +179,7 @@ impl<M: GuestAddressSpace> DescriptorChain<M> {
     }
 
     /// Create a new `DescriptorChain` instance.
-    fn new(mem: M::T, desc_table: GuestAddress, queue_size: u16, head_index: u16) -> Self {
+    pub fn new(mem: M::T, desc_table: GuestAddress, queue_size: u16, head_index: u16) -> Self {
         Self::with_ttl(mem, desc_table, queue_size, queue_size, head_index)
     }
 


### PR DESCRIPTION
Make DescriptorChain::new() public, so it can be used by other crates
(specially for testing).

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>