### PR TITLE
queue: fix license for publishing v0.1.0

### DIFF
--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -6,7 +6,7 @@ description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"
 keywords = ["virtio"]
 readme = "README.md"
-license = "Apache-2.0 OR MIT"
+license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
The virito-queue crate should licensed by either Apache 2.0 or
BSD-3-Clause.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>