### PR TITLE
virtio-queue: Add helpers for accessing queue information

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.0,
+  "coverage_score": 90.3,
   "exclude_path": "crates/virtio-queue/src/mock.rs",
   "crate_features": "virtio-blk/backend-stdio"
 }

--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -154,6 +154,9 @@ pub trait QueueStateT: for<'a> QueueStateGuard<'a> {
     /// Read the `idx` field from the available ring.
     fn avail_idx<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error>;
 
+    /// Read the `idx` field from the used ring.
+    fn used_idx<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error>;
+
     /// Put a used descriptor head into the used ring.
     fn add_used<M: GuestMemory>(&mut self, mem: &M, head_index: u16, len: u32)
         -> Result<(), Error>;
@@ -181,4 +184,10 @@ pub trait QueueStateT: for<'a> QueueStateGuard<'a> {
 
     /// Set the index of the next entry in the available ring.
     fn set_next_avail(&mut self, next_avail: u16);
+
+    /// Return the index for the next descriptor in the used ring.
+    fn next_used(&self) -> u16;
+
+    /// Set the index for the next descriptor in the used ring.
+    fn set_next_used(&mut self, next_used: u16);
 }

--- a/crates/virtio-queue/src/state.rs
+++ b/crates/virtio-queue/src/state.rs
@@ -311,6 +311,17 @@ impl QueueStateT for QueueState {
             .map_err(Error::GuestMemory)
     }
 
+    fn used_idx<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error> {
+        let addr = self
+            .used_ring
+            .checked_add(2)
+            .ok_or(Error::AddressOverflow)?;
+
+        mem.load(addr, order)
+            .map(Wrapping)
+            .map_err(Error::GuestMemory)
+    }
+
     fn add_used<M: GuestMemory>(
         &mut self,
         mem: &M,
@@ -415,7 +426,15 @@ impl QueueStateT for QueueState {
         self.next_avail.0
     }
 
+    fn next_used(&self) -> u16 {
+        self.next_used.0
+    }
+
     fn set_next_avail(&mut self, next_avail: u16) {
         self.next_avail = Wrapping(next_avail);
+    }
+
+    fn set_next_used(&mut self, next_used: u16) {
+        self.next_used = Wrapping(next_used);
     }
 }


### PR DESCRIPTION
These helpers are meant to help crate's consumers getting and setting
information about the queue.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>