### PR TITLE
Fix warnings and update test coverage

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.7,
+  "coverage_score": 90.0,
   "exclude_path": "crates/virtio-queue/src/mock.rs",
   "crate_features": "virtio-blk/backend-stdio"
 }

--- a/crates/virtio-device/src/lib.rs
+++ b/crates/virtio-device/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
             assert_eq!(d.cfg.device_features & (1 << VIRTIO_F_RING_EVENT_IDX), 0);
 
             for q in d.cfg.queues.iter() {
-                assert_eq!(q.state.event_idx_enabled, false);
+                assert!(!q.state.event_idx_enabled);
             }
 
             // Revert status.
@@ -302,7 +302,7 @@ mod tests {
             assert_eq!(d.cfg.device_status, status);
 
             for q in d.cfg.queues.iter() {
-                assert_eq!(q.state.event_idx_enabled, true);
+                assert!(q.state.event_idx_enabled);
             }
         }
 

--- a/crates/virtio-device/src/mmio.rs
+++ b/crates/virtio-device/src/mmio.rs
@@ -234,12 +234,12 @@ mod tests {
         assert_eq!(mmio_read(&d, 0x10), 0);
 
         // Attempt to write some feature acknowledged by the driver.
-        d.write(0x20, &driver_features.as_slice());
+        d.write(0x20, driver_features.as_slice());
         // Nothing happens because the device status is no appropriate.
         assert_eq!(d.cfg.driver_features, 0);
 
         d.cfg.device_status = status::DRIVER;
-        d.write(0x20, &driver_features.as_slice());
+        d.write(0x20, driver_features.as_slice());
         assert_eq!(d.cfg.driver_features, driver_features as u64);
 
         d.write(0x24, &1u32.to_le_bytes());

--- a/crates/virtio-queue/src/descriptor.rs
+++ b/crates/virtio-queue/src/descriptor.rs
@@ -224,19 +224,19 @@ mod tests {
         assert_eq!(desc.len(), 0x2000);
         desc.set_flags(VIRTQ_DESC_F_NEXT);
         assert_eq!(desc.flags(), VIRTQ_DESC_F_NEXT);
-        assert_eq!(desc.has_next(), true);
-        assert_eq!(desc.is_write_only(), false);
-        assert_eq!(desc.refers_to_indirect_table(), false);
+        assert!(desc.has_next());
+        assert!(!desc.is_write_only());
+        assert!(!desc.refers_to_indirect_table());
         desc.set_flags(VIRTQ_DESC_F_WRITE);
         assert_eq!(desc.flags(), VIRTQ_DESC_F_WRITE);
-        assert_eq!(desc.has_next(), false);
-        assert_eq!(desc.is_write_only(), true);
-        assert_eq!(desc.refers_to_indirect_table(), false);
+        assert!(!desc.has_next());
+        assert!(desc.is_write_only());
+        assert!(!desc.refers_to_indirect_table());
         desc.set_flags(VIRTQ_DESC_F_INDIRECT);
         assert_eq!(desc.flags(), VIRTQ_DESC_F_INDIRECT);
-        assert_eq!(desc.has_next(), false);
-        assert_eq!(desc.is_write_only(), false);
-        assert_eq!(desc.refers_to_indirect_table(), true);
+        assert!(!desc.has_next());
+        assert!(!desc.is_write_only());
+        assert!(desc.refers_to_indirect_table());
         desc.set_next(3);
         assert_eq!(desc.next(), 3);
     }

--- a/crates/virtio-queue/src/queue_guard.rs
+++ b/crates/virtio-queue/src/queue_guard.rs
@@ -201,7 +201,7 @@ mod tests {
 
         // g is currently valid.
         assert!(g.is_valid());
-        assert_eq!(g.ready(), true);
+        assert!(g.ready());
         assert_eq!(g.max_size(), 0x100);
         g.set_size(16);
 
@@ -239,7 +239,7 @@ mod tests {
         // The next chain that can be consumed should have index 3.
         assert_eq!(g.next_avail(), 3);
         assert_eq!(g.avail_idx(Ordering::Acquire).unwrap(), Wrapping(3));
-        assert_eq!(g.ready(), true);
+        assert!(g.ready());
 
         // Decrement `idx` which should be forbidden. We don't enforce this thing, but we should
         // test that we don't panic in case the driver decrements it.

--- a/crates/virtio-queue/src/state_sync.rs
+++ b/crates/virtio-queue/src/state_sync.rs
@@ -159,21 +159,21 @@ mod tests {
         let t1 = std::thread::spawn(move || {
             {
                 let guard = q2.lock();
-                assert_eq!(guard.ready(), false);
+                assert!(!guard.ready());
             }
             b2.wait();
             b2.wait();
             {
                 let guard = q2.lock();
-                assert_eq!(guard.ready(), true);
+                assert!(guard.ready());
             }
         });
 
         let t2 = std::thread::spawn(move || {
-            assert_eq!(q3.ready(), false);
+            assert!(!q3.ready());
             b3.wait();
             b3.wait();
-            assert_eq!(q3.ready(), true);
+            assert!(q3.ready());
         });
 
         barrier.wait();
@@ -194,7 +194,7 @@ mod tests {
         q.set_used_ring_address(Some(0x3000), None);
         q.set_event_idx(true);
         q.set_ready(true);
-        assert_eq!(q.is_valid(m.memory()), true);
+        assert!(q.is_valid(m.memory()));
         assert_eq!(q.lock().size, 0x100);
 
         assert_eq!(q.max_size(), 0x100);
@@ -230,13 +230,13 @@ mod tests {
         q.set_next_avail(2);
         q.set_size(0x8);
         q.set_ready(true);
-        assert_eq!(q.is_valid(m.memory()), true);
+        assert!(q.is_valid(m.memory()));
 
         q.add_used(m.memory(), 1, 0x100).unwrap();
         q.needs_notification(m.memory()).unwrap();
 
         assert_eq!(q.lock_state().size, 0x8);
-        assert_eq!(q.lock_state().ready, true);
+        assert!(q.lock_state().ready);
         assert_ne!(
             q.lock_state().desc_table,
             GuestAddress(DEFAULT_DESC_TABLE_ADDR)
@@ -252,11 +252,11 @@ mod tests {
         assert_ne!(q.lock_state().next_avail, Wrapping(0));
         assert_ne!(q.lock_state().next_used, Wrapping(0));
         assert_ne!(q.lock_state().signalled_used, None);
-        assert_eq!(q.lock_state().event_idx_enabled, true);
+        assert!(q.lock_state().event_idx_enabled);
 
         q.reset();
         assert_eq!(q.lock_state().size, 0x100);
-        assert_eq!(q.lock_state().ready, false);
+        assert!(!q.lock_state().ready);
         assert_eq!(
             q.lock_state().desc_table,
             GuestAddress(DEFAULT_DESC_TABLE_ADDR)
@@ -272,7 +272,7 @@ mod tests {
         assert_eq!(q.lock_state().next_avail, Wrapping(0));
         assert_eq!(q.lock_state().next_used, Wrapping(0));
         assert_eq!(q.lock_state().signalled_used, None);
-        assert_eq!(q.lock_state().event_idx_enabled, false);
+        assert!(!q.lock_state().event_idx_enabled);
     }
 
     #[test]
@@ -285,11 +285,11 @@ mod tests {
         q.set_avail_ring_address(Some(0x2000), None);
         q.set_used_ring_address(Some(0x3000), None);
         q.set_ready(true);
-        assert_eq!(q.is_valid(mem), true);
+        assert!(q.is_valid(mem));
 
         let used_addr = q.lock_state().used_ring;
 
-        assert_eq!(q.lock_state().event_idx_enabled, false);
+        assert!(!q.lock_state().event_idx_enabled);
         q.enable_notification(mem).unwrap();
         let v = m.read_obj::<u16>(used_addr).map(u16::from_le).unwrap();
         assert_eq!(v, 0);
@@ -307,15 +307,15 @@ mod tests {
         m.write_obj::<u16>(u16::to_le(2), avail_addr.unchecked_add(2))
             .unwrap();
 
-        assert_eq!(q.enable_notification(mem).unwrap(), true);
+        assert!(q.enable_notification(mem).unwrap());
         q.lock_state().next_avail = Wrapping(2);
-        assert_eq!(q.enable_notification(mem).unwrap(), false);
+        assert!(!q.enable_notification(mem).unwrap());
 
         m.write_obj::<u16>(u16::to_le(8), avail_addr.unchecked_add(2))
             .unwrap();
 
-        assert_eq!(q.enable_notification(mem).unwrap(), true);
+        assert!(q.enable_notification(mem).unwrap());
         q.lock_state().next_avail = Wrapping(8);
-        assert_eq!(q.enable_notification(mem).unwrap(), false);
+        assert!(!q.enable_notification(mem).unwrap());
     }
 }


### PR DESCRIPTION
This PR includes the original one from dependabot #133 
It fixes clippy warnings and test coverage due to updated Rust version.