### PR TITLE
Fix `QueueState::used_idx` and `test_queue_guard_object` on s390x (endianess issues).

### DIFF
--- a/crates/virtio-queue/src/queue_guard.rs
+++ b/crates/virtio-queue/src/queue_guard.rs
@@ -231,11 +231,11 @@ mod tests {
             vq.desc_table().store(i, desc);
         }
 
-        vq.avail().ring().ref_at(0).store(0);
-        vq.avail().ring().ref_at(1).store(2);
-        vq.avail().ring().ref_at(2).store(5);
+        vq.avail().ring().ref_at(0).store(u16::to_le(0));
+        vq.avail().ring().ref_at(1).store(u16::to_le(2));
+        vq.avail().ring().ref_at(2).store(u16::to_le(5));
         // Let the device know it can consume chains with the index < 2.
-        vq.avail().idx().store(3);
+        vq.avail().idx().store(u16::to_le(3));
         // No descriptor chains are consumed at this point.
         assert_eq!(g.next_avail(), 0);
         assert_eq!(g.next_used(), 0);

--- a/crates/virtio-queue/src/state.rs
+++ b/crates/virtio-queue/src/state.rs
@@ -318,6 +318,7 @@ impl QueueStateT for QueueState {
             .ok_or(Error::AddressOverflow)?;
 
         mem.load(addr, order)
+            .map(u16::from_le)
             .map(Wrapping)
             .map_err(Error::GuestMemory)
     }


### PR DESCRIPTION
Fix `QueueState::used_idx` and `test_queue_guard_object` on s390x (endianess issues).
