### PR TITLE
Improve the usability of queue interfaces

### DIFF
--- a/crates/virtio-queue/src/iterator.rs
+++ b/crates/virtio-queue/src/iterator.rs
@@ -102,7 +102,7 @@ pub struct AvailIter<'b, M> {
 impl<'b, M> AvailIter<'b, M>
 where
     M: Deref,
-    M::Target: GuestMemory + Sized,
+    M::Target: GuestMemory,
 {
     /// Create a new instance of `AvailInter`.
     ///

--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -206,3 +206,20 @@ pub trait QueueStateT: for<'a> QueueStateGuard<'a> {
         M: Clone + Deref,
         M::Target: GuestMemory;
 }
+
+/// Trait to access and manipulate a Virtio queue that's known to be exclusively accessed
+/// by a single execution thread.
+pub trait QueueStateOwnedT: QueueStateT {
+    /// Get a consuming iterator over all available descriptor chain heads offered by the driver.
+    ///
+    /// # Arguments
+    /// * `mem` - the `GuestMemory` object that can be used to access the queue buffers.
+    fn iter<M>(&mut self, mem: M) -> Result<AvailIter<'_, M>, Error>
+    where
+        M: Deref,
+        M::Target: GuestMemory;
+
+    /// Undo the last advancement of the next available index field by decrementing its
+    /// value by one.
+    fn go_to_previous_position(&mut self);
+}

--- a/crates/virtio-queue/src/queue.rs
+++ b/crates/virtio-queue/src/queue.rs
@@ -16,7 +16,9 @@ use std::sync::atomic::Ordering;
 
 use vm_memory::GuestAddressSpace;
 
-use crate::{AvailIter, Error, QueueGuard, QueueState, QueueStateGuard, QueueStateT};
+use crate::{
+    AvailIter, Error, QueueGuard, QueueState, QueueStateGuard, QueueStateOwnedT, QueueStateT,
+};
 
 /// A convenient wrapper struct for a virtio queue, with associated `GuestMemory` object.
 ///

--- a/crates/virtio-queue/src/queue_guard.rs
+++ b/crates/virtio-queue/src/queue_guard.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 
 use vm_memory::GuestMemory;
 
-use crate::{AvailIter, Error, QueueState, QueueStateT};
+use crate::{AvailIter, Error, QueueState, QueueStateOwnedT, QueueStateT};
 
 /// A guard object to exclusively access an `Queue` object.
 ///


### PR DESCRIPTION
This RFC suggests a solution addressing the shortcomings mentioned in #144 (there are some very small orthogonal changes that got through as well). Not sure if the choice of naming for the new trait is the best, but the approach is to use that to explicitly gate operations that are only safe/sane when we know for sure accesses are not performed in a multi-threaded context.