### PR TITLE
Minor refinement to QueueState and QueueStateT

### DIFF
--- a/crates/virtio-queue/CHANGELOG.md
+++ b/crates/virtio-queue/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Added
+- QueueStateT::size(): [#153](https://github.com/rust-vmm/vm-virtio/pull/153)
+
+## Removed
+- #[derive(Clone)] for QueueState: [#153](https://github.com/rust-vmm/vm-virtio/pull/153)
+
 # v0.2.0
 
 ## Added

--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -121,6 +121,9 @@ pub trait QueueStateT: for<'a> QueueStateGuard<'a> {
     /// Get the maximum size of the virtio queue.
     fn max_size(&self) -> u16;
 
+    /// Get the actual size configured by the guest.
+    fn size(&self) -> u16;
+
     /// Configure the queue size for the virtio queue.
     fn set_size(&mut self, size: u16);
 

--- a/crates/virtio-queue/src/state.rs
+++ b/crates/virtio-queue/src/state.rs
@@ -22,7 +22,7 @@ use crate::defs::{
 use crate::{error, AvailIter, Descriptor, Error, QueueStateGuard, QueueStateT, VirtqUsedElem};
 
 /// Struct to maintain information and manipulate state of a virtio queue.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct QueueState {
     /// The maximum size in elements offered by the device.
     pub max_size: u16,

--- a/crates/virtio-queue/src/state.rs
+++ b/crates/virtio-queue/src/state.rs
@@ -242,6 +242,10 @@ impl QueueStateT for QueueState {
         self.max_size
     }
 
+    fn size(&self) -> u16 {
+        self.size
+    }
+
     fn set_size(&mut self, size: u16) {
         if size > self.max_size() || size == 0 || (size & (size - 1)) != 0 {
             error!("virtio queue with invalid size: {}", size);
@@ -427,12 +431,12 @@ impl QueueStateT for QueueState {
         self.next_avail.0
     }
 
-    fn next_used(&self) -> u16 {
-        self.next_used.0
-    }
-
     fn set_next_avail(&mut self, next_avail: u16) {
         self.next_avail = Wrapping(next_avail);
+    }
+
+    fn next_used(&self) -> u16 {
+        self.next_used.0
     }
 
     fn set_next_used(&mut self, next_used: u16) {

--- a/crates/virtio-queue/src/state_sync.rs
+++ b/crates/virtio-queue/src/state_sync.rs
@@ -75,6 +75,10 @@ impl QueueStateT for QueueStateSync {
         self.lock_state().max_size()
     }
 
+    fn size(&self) -> u16 {
+        self.lock_state().size()
+    }
+
     fn set_size(&mut self, size: u16) {
         self.lock_state().set_size(size);
     }
@@ -136,12 +140,12 @@ impl QueueStateT for QueueStateSync {
         self.lock_state().next_avail()
     }
 
-    fn next_used(&self) -> u16 {
-        self.lock_state().next_used()
-    }
-
     fn set_next_avail(&mut self, next_avail: u16) {
         self.lock_state().set_next_avail(next_avail);
+    }
+
+    fn next_used(&self) -> u16 {
+        self.lock_state().next_used()
     }
 
     fn set_next_used(&mut self, next_used: u16) {
@@ -210,7 +214,9 @@ mod tests {
         assert_eq!(q.lock().size, 0x100);
 
         assert_eq!(q.max_size(), 0x100);
+        assert_eq!(q.size(), 0x100);
         q.set_size(0x80);
+        assert_eq!(q.size(), 0x80);
         assert_eq!(q.max_size(), 0x100);
         q.set_next_avail(5);
         assert_eq!(q.next_avail(), 5);


### PR DESCRIPTION
### Summary of the PR

1) Remove `#[derive(Clone)]` for `QueueState`.
2) Add method `size()` to `QueueStateT`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
