### PR TITLE
[RFC] Improve the efficiency of `needs_notification` for queues

### DIFF
--- a/crates/virtio-queue-ser/src/state.rs
+++ b/crates/virtio-queue-ser/src/state.rs
@@ -21,8 +21,9 @@ pub struct QueueStateSer {
     pub next_used: u16,
     /// VIRTIO_F_RING_EVENT_IDX negotiated.
     pub event_idx_enabled: bool,
-    /// The last used value when using VIRTIO_F_EVENT_IDX.
-    pub signalled_used: Option<u16>,
+    /// The number of descriptor chains placed in the used ring via `add_used`
+    /// since the last time `needs_notification` was called on the associated queue.
+    pub num_added: u16,
     /// The queue size in elements the driver selected.
     pub size: u16,
     /// Indicates if the queue finished with the configuration.
@@ -55,7 +56,7 @@ impl From<&QueueStateSer> for QueueState {
             next_avail: Wrapping(state.next_avail),
             next_used: Wrapping(state.next_used),
             event_idx_enabled: state.event_idx_enabled,
-            signalled_used: state.signalled_used.map(Wrapping),
+            num_added: Wrapping(state.num_added),
             size: state.size,
             ready: state.ready,
             desc_table: GuestAddress(state.desc_table),
@@ -72,7 +73,7 @@ impl From<&QueueState> for QueueStateSer {
             next_avail: state.next_avail.0,
             next_used: state.next_used.0,
             event_idx_enabled: state.event_idx_enabled,
-            signalled_used: state.signalled_used.map(|value| value.0),
+            num_added: state.num_added.0,
             size: state.size,
             ready: state.ready,
             desc_table: state.desc_table.0,
@@ -101,7 +102,7 @@ mod tests {
             next_avail: Wrapping(SOME_VALUE - 1),
             next_used: Wrapping(SOME_VALUE + 1),
             event_idx_enabled: false,
-            signalled_used: None,
+            num_added: Wrapping(0),
             size: SOME_VALUE,
             ready: true,
             desc_table: GuestAddress(SOME_VALUE as u64),

--- a/crates/virtio-queue/src/state_sync.rs
+++ b/crates/virtio-queue/src/state_sync.rs
@@ -291,7 +291,7 @@ mod tests {
         );
         assert_ne!(q.lock_state().next_avail, Wrapping(0));
         assert_ne!(q.lock_state().next_used, Wrapping(0));
-        assert_ne!(q.lock_state().signalled_used, None);
+        assert_eq!(q.lock_state().num_added, Wrapping(0));
         assert!(q.lock_state().event_idx_enabled);
 
         q.reset();
@@ -311,7 +311,7 @@ mod tests {
         );
         assert_eq!(q.lock_state().next_avail, Wrapping(0));
         assert_eq!(q.lock_state().next_used, Wrapping(0));
-        assert_eq!(q.lock_state().signalled_used, None);
+        assert_eq!(q.lock_state().num_added, Wrapping(0));
         assert!(!q.lock_state().event_idx_enabled);
     }
 


### PR DESCRIPTION
This PR proposes an improvement to the efficiency of storing state and executing functionality related to the `needs_notification` queue logic. It replaces the current `signalled_used: Option<Wrapping<u16>>` member of the state structure with a `num_added: Wrapping<u16>` (which keeps track of how many descriptor chains have been added to the used ring since the last call to `needs_notification`), and also simplifies the logic in `needs_notification`.

A similar approach is used in the Linux virtio code as well (one example can be found [here](https://elixir.bootlin.com/linux/v5.15.35/source/drivers/virtio/virtio_ring.c#L661)). It appears to bring noticeable performance improvements in use cases where `needs_notification` calls constitute an increased proportion of the overall budget allocated for device model functionality (i.e. when using io_uring-based backends).