### PR TITLE
virtio-queue: small fixes to docs

### DIFF
--- a/crates/virtio-queue/README.md
+++ b/crates/virtio-queue/README.md
@@ -109,7 +109,7 @@ following, as showed in the diagram below as well:
 10. the device sends a used buffer notification to the driver if such
     notifications are not suppressed.
 
-![queue](docs/images/queue.png)
+![queue](https://raw.githubusercontent.com/rust-vmm/vm-virtio/main/crates/virtio-queue/docs/images/queue.png)
 
 A descriptor is storing four fields, with the first two, `addr` and `len`,
 pointing to the data in memory to which the descriptor refers, as shown in the
@@ -118,7 +118,7 @@ buffer is device readable or writable, or if we have another descriptor chained
 after this one (VIRTQ_DESC_F_NEXT flag set). `next` field is storing the index
 of the next descriptor if VIRTQ_DESC_F_NEXT is set.
 
-![](docs/images/descriptor.png)
+![descriptor](https://raw.githubusercontent.com/rust-vmm/vm-virtio/main/crates/virtio-queue/docs/images/descriptor.png)
 
 **Requirements for device implementation**
 

--- a/crates/virtio-queue/src/state.rs
+++ b/crates/virtio-queue/src/state.rs
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// WARNING: The way the `QueueState` is defined now, it can be used as the queue object, therefore
 /// it is allowed to set up and use an invalid queue (initialized with random data since the
-/// `QueueState`'s fields are public). When fixing https://github.com/rust-vmm/vm-virtio/issues/143,
+/// `QueueState`'s fields are public). When fixing <https://github.com/rust-vmm/vm-virtio/issues/143>,
 /// we plan to rename `QueueState` to `Queue`, and define a new `QueueState` that would be the
 /// actual state of the queue (no `Wrapping`s in it, for example). This way, we will also be able to
 /// do the checks that we normally do in the queue's field setters when starting from scratch, when


### PR DESCRIPTION
### Summary of the PR

Did a few fixes before publishing virtio-queue 0.3.0.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
