### PR TITLE
Add initial virtio console implementation

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 89.6,
+  "coverage_score": 88.6,
   "exclude_path": "crates/virtio-queue/src/mock.rs",
   "crate_features": "virtio-blk/backend-stdio"
 }

--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "virtio-console"
 version = "0.1.0"
-authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
+authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>",
+    "Niculae Radu-Alexandru <r.niculae99@gmail.com>"]
 description = "virtio console device implementation"
-repository = "https://github.com/RaduNiculae/vm-virtio"
+repository = "https://github.com/rust-vmm/vm-virtio"
 keywords = ["virtio", "console"]
 readme = "README.md"
 license = "Apache-2.0 OR BSD-3-Clause"
@@ -11,5 +12,5 @@ edition = "2021"
 
 
 [dependencies]
-virtio-queue = { path = "../../virtio-queue" }
+virtio-queue = { path = "../../virtio-queue", version = ">=0.3.0" }
 vm-memory = "0.8.0"

--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "virtio-console"
+version = "0.1.0"
+authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
+description = "virtio console device implementation"
+repository = "https://github.com/RaduNiculae/vm-virtio"
+keywords = ["virtio", "console"]
+readme = "README.md"
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2021"
+
+
+[dependencies]
+virtio-queue = { path = "../../virtio-queue" }
+vm-memory = "0.8.0"

--- a/crates/devices/virtio-console/src/console.rs
+++ b/crates/devices/virtio-console/src/console.rs
@@ -1,0 +1,105 @@
+use std::cmp;
+use std::io::{Write};
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
+use virtio_queue::{DescriptorChain};
+use vm_memory::{Bytes, GuestMemory};
+
+/// Console device resize feature.
+pub const VIRTIO_CONSOLE_F_SIZE: u64 = 0;
+
+/// Console device multiport feature.
+pub const VIRTIO_CONSOLE_F_MULTIPORT: u64 = 1;
+
+/// Console device emergency write feature.
+pub const VIRTIO_CONSOLE_F_EMERG_WRITE: u64 = 2;
+
+
+/// Console struct
+pub struct Console {
+    /// Data to send to the driver via receiveq
+    input_buffer: Arc<Mutex<Vec<u8>>>,
+
+    // /// Driver acked features
+    // features: u64,
+}
+
+impl Console {
+    /// Create new console object
+    pub fn new() -> Self{
+        Console {
+            input_buffer: Arc::new(Mutex::new(Vec::new())),
+            // features,
+        }
+    }
+
+    // fn has_feature(&self, feature_pos: u64) -> bool {
+    //     (self.features & (1u64 << feature_pos)) != 0
+    // }
+
+    /// Add data to the input buffer
+    pub fn enqueue_data(&self, data: &mut Vec<u8>) {
+        let mut input_buffer = self.input_buffer.lock().unwrap();
+        input_buffer.append(data);
+    }
+
+    /// Check if input buffer is empty
+    pub fn is_input_buffer_empty(&self) -> bool {
+        let input_buffer = self.input_buffer.lock().unwrap();
+        input_buffer.is_empty()
+    }
+
+    /// Process transmitq chain
+    pub fn process_transmitq_chain<M, T>(&self, desc_chain: &mut DescriptorChain<M>, output: &mut T) -> usize
+        where
+            M: Deref,
+            M::Target: GuestMemory,
+            T: Write,
+    {
+        let mut len = 0;
+        while let Some(desc) = desc_chain.next() {
+            len = len + desc_chain.memory().write_to(
+                desc.addr(),
+                output,
+                desc.len() as usize,
+            ).unwrap();
+            let _ = output.flush();
+        }
+
+        len
+    }
+
+    /// Process receiveq chain
+    pub fn process_receiveq_chain<M>(&self, desc_chain: &mut DescriptorChain<M>) -> usize
+        where
+            M: Deref,
+            M::Target: GuestMemory,
+    {
+        let mut sent_bytes: usize = 0;
+        let mut input_buffer = self.input_buffer.lock().unwrap();
+
+        if input_buffer.is_empty() {
+            return 0;
+        }
+
+        while let Some(desc) = desc_chain.next() {
+            let len_write = cmp::min(desc.len() as usize, input_buffer.len() as usize);
+            let buffer_slice = input_buffer.drain(..len_write).collect::<Vec<u8>>();
+
+            if let Err(err) = desc_chain.memory().write_slice(
+                &buffer_slice[..],
+                desc.addr()
+            ) {
+                println!("Failed to write slice: {:?}", err);
+                break;
+            }
+            sent_bytes += len_write;
+
+            if input_buffer.is_empty() {
+                break;
+            }
+        }
+
+        sent_bytes
+    }
+}

--- a/crates/devices/virtio-console/src/console.rs
+++ b/crates/devices/virtio-console/src/console.rs
@@ -1,98 +1,169 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 use std::cmp;
-use std::io::{Write};
+use std::fmt::{self, Display};
+use std::io::Write;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
-use virtio_queue::{DescriptorChain};
-use vm_memory::{Bytes, GuestMemory};
+use virtio_queue::DescriptorChain;
+use vm_memory::{Bytes, GuestMemory, GuestMemoryError};
 
-/// Console device resize feature.
-pub const VIRTIO_CONSOLE_F_SIZE: u64 = 0;
+/// Virtio console chain processing abstraction.
+///
+/// This module offers an abstraction for working with the descriptor chains of the receive and
+/// transmit queues.
+///  * The transmit queue is used to send data from the driver to the device and it's buffers are
+///    read-only for the device.
+///  * The receive queue is used to send data from the device to the driver and it's buffers are
+///    write-only for the device.
+///
+/// To implement this abstraction the [`Console`](struct.Console.html)  structure is provided which
+/// consists of the `input_buffer` member and exposes several methods.
+/// * The [`input_buffer`](struct.Console.html#field.input_buffer) is a buffer used to store data
+///   before sending it to the driver. The following methods are provided to interact with it:
+///   - [`enqueue_data`](struct.Console.html#method.enqueue_data) which is used to add data to the
+///     end of the buffer.
+///   - [`is_input_buffer_empty`](struct.Console.html#method.is_input_buffer_empty) which is used
+///     assess if there is any data waiting to be sent.
+///
+/// The methods for processing a descriptor chain are the following:
+/// *  [`process_transmitq_chain`](struct.Console.html#method.process_transmitq_chain) which is
+///    used to read the data from a descriptor chain of the transmit queue.
+/// * [`process_receiveq_chain`](struct.Console.html#method.process_receiveq_chain) which is used
+///   to send the data to the driver by writing it into the buffers of a receive queue descriptor
+///   chain.
 
-/// Console device multiport feature.
-pub const VIRTIO_CONSOLE_F_MULTIPORT: u64 = 1;
+/// Console device errors.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to write slice to guest memory.
+    WriteToGuestFailed(GuestMemoryError),
+}
 
-/// Console device emergency write feature.
-pub const VIRTIO_CONSOLE_F_EMERG_WRITE: u64 = 2;
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
 
+        match self {
+            WriteToGuestFailed(ref err) => {
+                write!(f, "console failed to write slice to guest memory: {}", err)
+            }
+        }
+    }
+}
 
-/// Console struct
+/// Console struct that implements the abstraction of virtio console descriptor chain handling.
 pub struct Console {
-    /// Data to send to the driver via receiveq
+    /// Buffer that stores data to be sent to the driver.
     input_buffer: Arc<Mutex<Vec<u8>>>,
-
-    // /// Driver acked features
-    // features: u64,
 }
 
 impl Console {
-    /// Create new console object
-    pub fn new() -> Self{
+    /// Create new console object.
+    pub fn new() -> Self {
         Console {
             input_buffer: Arc::new(Mutex::new(Vec::new())),
-            // features,
         }
     }
 
-    // fn has_feature(&self, feature_pos: u64) -> bool {
-    //     (self.features & (1u64 << feature_pos)) != 0
-    // }
-
-    /// Add data to the input buffer
+    /// Adds data in the form of raw bytes to the input buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A mutable reference to a `Vec<u8>` containing the raw bytes that will be
+    ///            sent to the driver when the `process_receiveq_chian` method is called.
     pub fn enqueue_data(&self, data: &mut Vec<u8>) {
         let mut input_buffer = self.input_buffer.lock().unwrap();
         input_buffer.append(data);
     }
 
-    /// Check if input buffer is empty
+    /// Checks if input buffer is empty.
     pub fn is_input_buffer_empty(&self) -> bool {
         let input_buffer = self.input_buffer.lock().unwrap();
         input_buffer.is_empty()
     }
 
-    /// Process transmitq chain
-    pub fn process_transmitq_chain<M, T>(&self, desc_chain: &mut DescriptorChain<M>, output: &mut T) -> usize
-        where
-            M: Deref,
-            M::Target: GuestMemory,
-            T: Write,
+    /// Read data from a `desc_chain` of the transmit queue and write it to a specified output.
+    ///
+    /// # Arguments
+    /// * `desc_chain` - A mutable reference to the descriptor chain that should point to the
+    ///                  buffers that the virtio console driver has sent to the device.
+    /// * `output` - An object that implements the `Write` trait and specifies where the data
+    ///              should be written to (usually `stdout`). The `output` object is not included
+    ///              as part of the [`Console`](struct.Console.html) struct and rather passed as an
+    ///              argument to enable more flexibility in choosing and changing the output sink
+    ///              from a higher level without having to reinitialize the
+    ///              [`Console`](struct.Console.html) structure.
+    ///
+    /// # Returns
+    /// The length in bytes of the processes data.
+    pub fn process_transmitq_chain<M, T>(
+        &self,
+        desc_chain: &mut DescriptorChain<M>,
+        output: &mut T,
+    ) -> usize
+    where
+        M: Deref,
+        M::Target: GuestMemory,
+        T: Write,
     {
+        // Iterate through all the buffers in the chain and write the data to output.
         let mut len = 0;
         while let Some(desc) = desc_chain.next() {
-            len = len + desc_chain.memory().write_to(
-                desc.addr(),
-                output,
-                desc.len() as usize,
-            ).unwrap();
+            len += desc_chain
+                .memory()
+                .write_to(desc.addr(), output, desc.len() as usize)
+                .unwrap();
             let _ = output.flush();
         }
 
         len
     }
 
-    /// Process receiveq chain
-    pub fn process_receiveq_chain<M>(&self, desc_chain: &mut DescriptorChain<M>) -> usize
-        where
-            M: Deref,
-            M::Target: GuestMemory,
+    /// Takes data from the input buffer and writes it to guest memory in the specified
+    /// descriptor chain. The empty descriptor chain in which the data is written has previously
+    /// been added to the receive queue by the driver.
+    /// If there are not enough buffers to hold all the data, we stop and wait for the driver to
+    /// add more.
+    ///
+    /// # Arguments
+    /// * `desc_chain` - A mutable reference to the descriptor chain that should point to the
+    ///                  empty buffers that the virtio driver has offered the device.
+    ///
+    /// # Returns
+    /// The number of raw bytes written to guest memory.
+    pub fn process_receiveq_chain<M>(
+        &self,
+        desc_chain: &mut DescriptorChain<M>,
+    ) -> Result<usize, Error>
+    where
+        M: Deref,
+        M::Target: GuestMemory,
     {
-        let mut sent_bytes: usize = 0;
+        // Acquire lock on buffer to make sure no other thread is adding data to it while it is
+        // being processed.
         let mut input_buffer = self.input_buffer.lock().unwrap();
+        let mut sent_bytes: usize = 0;
 
+        // When the driver adds a new descriptor chain to the receive queue this method will be
+        // called to write the remaining data to the newly provided buffers. If there is no
+        // remaining data waiting to be sent it can return 0.
         if input_buffer.is_empty() {
-            return 0;
+            return Ok(0);
         }
 
+        // Break up the data from the "input_buffer" into chunks that fit into the buffers of the
+        // receive queue descriptor chain and write it to guest memory.
         while let Some(desc) = desc_chain.next() {
-            let len_write = cmp::min(desc.len() as usize, input_buffer.len() as usize);
+            let len_write = cmp::min(desc.len() as usize, input_buffer.len());
             let buffer_slice = input_buffer.drain(..len_write).collect::<Vec<u8>>();
 
-            if let Err(err) = desc_chain.memory().write_slice(
-                &buffer_slice[..],
-                desc.addr()
-            ) {
-                println!("Failed to write slice: {:?}", err);
-                break;
-            }
+            desc_chain
+                .memory()
+                .write_slice(&buffer_slice, desc.addr())
+                .map_err(Error::WriteToGuestFailed)?;
+
             sent_bytes += len_write;
 
             if input_buffer.is_empty() {
@@ -100,6 +171,6 @@ impl Console {
             }
         }
 
-        sent_bytes
+        Ok(sent_bytes)
     }
 }

--- a/crates/devices/virtio-console/src/console.rs
+++ b/crates/devices/virtio-console/src/console.rs
@@ -1,44 +1,43 @@
 // Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Virtio console chain processing abstraction.
+//!
+//! This module offers an abstraction for working with the descriptor chains of the receive and
+//! transmit queues.
+//!  * The transmit queue is used to send data from the driver to the device and it's buffers are
+//!    read-only for the device.
+//!  * The receive queue is used to send data from the device to the driver and it's buffers are
+//!    write-only for the device.
+
 use std::cmp;
 use std::fmt::{self, Display};
-use std::io::Write;
+use std::io::{stdout, Stdout, Write};
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use virtio_queue::DescriptorChain;
 use vm_memory::{Bytes, GuestMemory, GuestMemoryError};
-
-/// Virtio console chain processing abstraction.
-///
-/// This module offers an abstraction for working with the descriptor chains of the receive and
-/// transmit queues.
-///  * The transmit queue is used to send data from the driver to the device and it's buffers are
-///    read-only for the device.
-///  * The receive queue is used to send data from the device to the driver and it's buffers are
-///    write-only for the device.
-///
-/// To implement this abstraction the [`Console`](struct.Console.html)  structure is provided which
-/// consists of the `input_buffer` member and exposes several methods.
-/// * The [`input_buffer`](struct.Console.html#field.input_buffer) is a buffer used to store data
-///   before sending it to the driver. The following methods are provided to interact with it:
-///   - [`enqueue_data`](struct.Console.html#method.enqueue_data) which is used to add data to the
-///     end of the buffer.
-///   - [`is_input_buffer_empty`](struct.Console.html#method.is_input_buffer_empty) which is used
-///     assess if there is any data waiting to be sent.
-///
-/// The methods for processing a descriptor chain are the following:
-/// *  [`process_transmitq_chain`](struct.Console.html#method.process_transmitq_chain) which is
-///    used to read the data from a descriptor chain of the transmit queue.
-/// * [`process_receiveq_chain`](struct.Console.html#method.process_receiveq_chain) which is used
-///   to send the data to the driver by writing it into the buffers of a receive queue descriptor
-///   chain.
 
 /// Console device errors.
 #[derive(Debug)]
 pub enum Error {
     /// Failed to write slice to guest memory.
     WriteToGuestFailed(GuestMemoryError),
+    /// Write to output sink failed.
+    WriteToOutputFailed(GuestMemoryError),
+    /// Transmitq descriptor chain length has overflown
+    ChainLengthOverflow,
+    /// Input buffer maximum capacity exceeded
+    BufferCapacityExceeded,
+    /// Read only descriptor that protocol says to write to.
+    UnexpectedReadOnlyDescriptor,
+    /// Write only descriptor that protocol says to read from.
+    UnexpectedWriteOnlyDescriptor,
+    /// The capacity passed to the constructor is either 0 or higher than [`MAX_CAPACITY`].
+    InvalidBufferCapacity,
+    /// Output sink flush has not written all bytes.
+    OutputSinkFlushFailed(std::io::Error),
 }
 
 impl Display for Error {
@@ -47,35 +46,138 @@ impl Display for Error {
 
         match self {
             WriteToGuestFailed(ref err) => {
-                write!(f, "console failed to write slice to guest memory: {}", err)
+                write!(f, "Console failed to write slice to guest memory: {}", err)
+            }
+            WriteToOutputFailed(ref err) => {
+                write!(f, "Console failed to write data to output sink: {}", err)
+            }
+            ChainLengthOverflow => {
+                write!(f, "Console transmitq chain length has overflown usize.")
+            }
+            BufferCapacityExceeded => {
+                write!(
+                    f,
+                    "Console input buffer maximum capacity has been exceeded."
+                )
+            }
+            UnexpectedReadOnlyDescriptor => {
+                write!(f, "Unexpected read-only descriptor.")
+            }
+            UnexpectedWriteOnlyDescriptor => {
+                write!(f, "Unexpected write-only descriptor.")
+            }
+            InvalidBufferCapacity => {
+                write!(
+                    f,
+                    "The capacity should not be 0 or higher than MAX_CAPACITY."
+                )
+            }
+            OutputSinkFlushFailed(ref err) => {
+                write!(f, "Output sink flush has not written all bytes: {}", err)
             }
         }
     }
 }
 
 /// Console struct that implements the abstraction of virtio console descriptor chain handling.
-pub struct Console {
+#[derive(Clone, Debug)]
+pub struct Console<T: Write> {
     /// Buffer that stores data to be sent to the driver.
     input_buffer: Arc<Mutex<Vec<u8>>>,
+    /// Capacity of the input buffer.
+    capacity: usize,
+    /// Output sink.
+    output: T,
 }
 
-impl Console {
-    /// Create new console object.
-    pub fn new() -> Self {
-        Console {
-            input_buffer: Arc::new(Mutex::new(Vec::new())),
+// TODO: Find the optimal DEFAULT_CAPACITY and MAX_CAPACITY through testing
+/// Maximum capacity of `input_buffer`.
+pub const MAX_CAPACITY: usize = 16384;
+
+/// Default capacity of `input_buffer`.
+///
+/// The value has been chosen to be the same size as the hvc console that is allocated in the linux
+/// [virtio console driver](https://github.com/torvalds/linux/blob/master/drivers/char/virtio_console.c#L1249).
+/// The value used in the kernel is `PAGE_SIZE` which is usually 4kB.
+pub const DEFAULT_CAPACITY: usize = 4096;
+
+impl Default for Console<Stdout> {
+    fn default() -> Self {
+        // It is safe to unwrap here since we are using DEFAULT_CAPACITY.
+        Self::new_with_capacity(DEFAULT_CAPACITY, stdout()).unwrap()
+    }
+}
+
+impl<T> Console<T>
+where
+    T: Write,
+{
+    /// Create new console object with the default `capacity`.
+    ///
+    /// # Arguments
+    /// * `output` - The output sink where all the data received from
+    ///              the transmitq will be written.
+    /// # Returns
+    /// The console object.
+    pub fn new(output: T) -> Self {
+        Self::new_with_capacity(DEFAULT_CAPACITY, output).unwrap()
+    }
+
+    /// Create new console object with specified `capacity`.
+    ///
+    /// # Arguments
+    /// * `capacity` - The capacity of the input buffer.
+    /// * `output` - The output sink where all the data received from
+    ///              the transmitq will be written.
+    /// # Returns
+    /// The console object or an `Error` if the capacity is 0 or higher than [`MAX_CAPACITY`].
+    pub fn new_with_capacity(capacity: usize, output: T) -> Result<Self, Error> {
+        // There is no use case for 0 capacity
+        if capacity == 0 || capacity > MAX_CAPACITY {
+            return Err(Error::InvalidBufferCapacity);
         }
+        Ok(Console {
+            input_buffer: Arc::new(Mutex::new(Vec::new())),
+            capacity,
+            output,
+        })
     }
 
     /// Adds data in the form of raw bytes to the input buffer.
     ///
-    /// # Arguments
+    /// The contents of the `Vec<u8>` sent as parameter will be moved to the input buffer.
+    /// If the length of the two combined vectors exceeds the maximum capacity an error will be
+    /// returned.
     ///
+    /// # Arguments
     /// * `data` - A mutable reference to a `Vec<u8>` containing the raw bytes that will be
-    ///            sent to the driver when the `process_receiveq_chian` method is called.
-    pub fn enqueue_data(&self, data: &mut Vec<u8>) {
+    ///            sent to the driver when the `process_receiveq_chain` method is called.
+    pub fn enqueue_data(&self, data: &mut Vec<u8>) -> Result<(), Error> {
         let mut input_buffer = self.input_buffer.lock().unwrap();
+        let total_length = input_buffer
+            .len()
+            .checked_add(data.len())
+            .ok_or(Error::BufferCapacityExceeded)?;
+        if total_length > self.capacity {
+            return Err(Error::BufferCapacityExceeded);
+        }
         input_buffer.append(data);
+
+        Ok(())
+    }
+
+    /// Returns the maximum number of bytes that can be added to the buffer.
+    pub fn available_capacity(&self) -> usize {
+        let input_buffer = self.input_buffer.lock().unwrap();
+        // Operation cannot underflow because any addition to the `input_buffer`
+        // is checked against `capacity`.
+        self.capacity - input_buffer.len()
+    }
+
+    /// Clear the input buffer.
+    pub fn clear_input_buffer(&self) {
+        let mut input_buffer = self.input_buffer.lock().unwrap();
+        input_buffer.clear();
     }
 
     /// Checks if input buffer is empty.
@@ -84,45 +186,39 @@ impl Console {
         input_buffer.is_empty()
     }
 
-    /// Read data from a `desc_chain` of the transmit queue and write it to a specified output.
+    /// Read data from a `desc_chain` of the transmit queue and write it to the output sink.
     ///
     /// # Arguments
     /// * `desc_chain` - A mutable reference to the descriptor chain that should point to the
     ///                  buffers that the virtio console driver has sent to the device.
-    /// * `output` - An object that implements the `Write` trait and specifies where the data
-    ///              should be written to (usually `stdout`). The `output` object is not included
-    ///              as part of the [`Console`](struct.Console.html) struct and rather passed as an
-    ///              argument to enable more flexibility in choosing and changing the output sink
-    ///              from a higher level without having to reinitialize the
-    ///              [`Console`](struct.Console.html) structure.
-    ///
-    /// # Returns
-    /// The length in bytes of the processes data.
-    pub fn process_transmitq_chain<M, T>(
-        &self,
+    pub fn process_transmitq_chain<M>(
+        &mut self,
         desc_chain: &mut DescriptorChain<M>,
-        output: &mut T,
-    ) -> usize
+    ) -> Result<(), Error>
     where
         M: Deref,
         M::Target: GuestMemory,
-        T: Write,
     {
         // Iterate through all the buffers in the chain and write the data to output.
-        let mut len = 0;
         while let Some(desc) = desc_chain.next() {
-            len += desc_chain
+            if desc.is_write_only() {
+                return Err(Error::UnexpectedWriteOnlyDescriptor);
+            }
+            desc_chain
                 .memory()
-                .write_to(desc.addr(), output, desc.len() as usize)
-                .unwrap();
-            let _ = output.flush();
+                .write_to(desc.addr(), &mut self.output, desc.len() as usize)
+                .map_err(Error::WriteToOutputFailed)?;
+
+            self.output.flush().map_err(Error::OutputSinkFlushFailed)?;
         }
 
-        len
+        Ok(())
     }
 
     /// Takes data from the input buffer and writes it to guest memory in the specified
-    /// descriptor chain. The empty descriptor chain in which the data is written has previously
+    /// descriptor chain.
+    ///
+    /// The empty descriptor chain in which the data is written has previously
     /// been added to the receive queue by the driver.
     /// If there are not enough buffers to hold all the data, we stop and wait for the driver to
     /// add more.
@@ -130,13 +226,12 @@ impl Console {
     /// # Arguments
     /// * `desc_chain` - A mutable reference to the descriptor chain that should point to the
     ///                  empty buffers that the virtio driver has offered the device.
-    ///
     /// # Returns
     /// The number of raw bytes written to guest memory.
     pub fn process_receiveq_chain<M>(
         &self,
         desc_chain: &mut DescriptorChain<M>,
-    ) -> Result<usize, Error>
+    ) -> Result<u32, Error>
     where
         M: Deref,
         M::Target: GuestMemory,
@@ -144,7 +239,7 @@ impl Console {
         // Acquire lock on buffer to make sure no other thread is adding data to it while it is
         // being processed.
         let mut input_buffer = self.input_buffer.lock().unwrap();
-        let mut sent_bytes: usize = 0;
+        let mut sent_bytes: u32 = 0;
 
         // When the driver adds a new descriptor chain to the receive queue this method will be
         // called to write the remaining data to the newly provided buffers. If there is no
@@ -156,14 +251,22 @@ impl Console {
         // Break up the data from the "input_buffer" into chunks that fit into the buffers of the
         // receive queue descriptor chain and write it to guest memory.
         while let Some(desc) = desc_chain.next() {
-            let len_write = cmp::min(desc.len() as usize, input_buffer.len());
-            let buffer_slice = input_buffer.drain(..len_write).collect::<Vec<u8>>();
+            if !desc.is_write_only() {
+                return Err(Error::UnexpectedReadOnlyDescriptor);
+            }
+            // Length of the input_buffer is lower than MAX_CAPACITY so it is safe to cast to u32.
+            let len_write = cmp::min(desc.len(), input_buffer.len() as u32);
+            let buffer_slice = input_buffer
+                .drain(..len_write as usize)
+                .collect::<Vec<u8>>();
 
             desc_chain
                 .memory()
                 .write_slice(&buffer_slice, desc.addr())
                 .map_err(Error::WriteToGuestFailed)?;
 
+            // Should not overflow since "input_buffer" can hold a maximum of MAX_CAPACITY which is
+            // lower than u32::MAX elements.
             sent_bytes += len_write;
 
             if input_buffer.is_empty() {
@@ -172,5 +275,240 @@ impl Console {
         }
 
         Ok(sent_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use virtio_queue::defs::VIRTQ_DESC_F_WRITE;
+    use virtio_queue::mock::MockSplitQueue;
+    use virtio_queue::Descriptor;
+    use vm_memory::{GuestAddress, GuestMemoryMmap};
+
+    impl PartialEq for Error {
+        fn eq(&self, other: &Self) -> bool {
+            use self::Error::*;
+            match (self, other) {
+                (WriteToGuestFailed(ref e), WriteToGuestFailed(ref other_e)) => {
+                    format!("{}", e).eq(&format!("{}", other_e))
+                }
+                (WriteToOutputFailed(ref e), WriteToOutputFailed(ref other_e)) => {
+                    format!("{}", e).eq(&format!("{}", other_e))
+                }
+                (ChainLengthOverflow, ChainLengthOverflow) => true,
+                (BufferCapacityExceeded, BufferCapacityExceeded) => true,
+                (UnexpectedReadOnlyDescriptor, UnexpectedReadOnlyDescriptor) => true,
+                (UnexpectedWriteOnlyDescriptor, UnexpectedWriteOnlyDescriptor) => true,
+                (InvalidBufferCapacity, InvalidBufferCapacity) => true,
+                _ => false,
+            }
+        }
+    }
+
+    const INPUT_VALUE: u8 = 42;
+    const INPUT_SIZE: u32 = 256;
+
+    #[test]
+    fn test_default_console() {
+        // Default console
+        let console1 = Console::default();
+        assert_eq!(console1.capacity, DEFAULT_CAPACITY);
+    }
+
+    #[test]
+    fn test_input_buffer_operations() {
+        assert_eq!(
+            Console::new_with_capacity(0, vec![0; DEFAULT_CAPACITY]).unwrap_err(),
+            Error::InvalidBufferCapacity
+        );
+
+        assert_eq!(
+            Console::new_with_capacity(MAX_CAPACITY + 1, vec![0; DEFAULT_CAPACITY]).unwrap_err(),
+            Error::InvalidBufferCapacity
+        );
+
+        let console =
+            Console::new_with_capacity(DEFAULT_CAPACITY, vec![0; DEFAULT_CAPACITY]).unwrap();
+        console
+            .enqueue_data(&mut vec![INPUT_VALUE; DEFAULT_CAPACITY])
+            .unwrap();
+        assert_eq!(
+            console.enqueue_data(&mut vec![INPUT_VALUE; 1]).unwrap_err(),
+            Error::BufferCapacityExceeded
+        );
+
+        console.clear_input_buffer();
+        assert!(console.is_input_buffer_empty());
+    }
+
+    #[test]
+    fn test_process_transmitq_chain() {
+        let output: Vec<u8> = Vec::new();
+        let mut console = Console::new_with_capacity(DEFAULT_CAPACITY, output).unwrap();
+
+        let mem: GuestMemoryMmap =
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x0001_0000)]).unwrap();
+
+        // One descriptor is write only
+        let v = vec![
+            Descriptor::new(0x1000, INPUT_SIZE, 0, 0),
+            Descriptor::new(0x2000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0),
+        ];
+
+        let queue = MockSplitQueue::new(&mem, 16);
+        // The `build_desc_chain` function will populate the `NEXT` related flags and field.
+        let mut chain = queue.build_desc_chain(&v[..2]).unwrap();
+        assert_eq!(
+            console.process_transmitq_chain(&mut chain).unwrap_err(),
+            Error::UnexpectedWriteOnlyDescriptor
+        );
+
+        // Descriptor is outside of the memory bounds
+        let v = vec![
+            Descriptor::new(0x0001_0000, INPUT_SIZE, 0, 0),
+            Descriptor::new(0x0002_0000, INPUT_SIZE, 0, 0),
+        ];
+        let mut chain = queue.build_desc_chain(&v[..2]).unwrap();
+        assert_eq!(
+            console.process_transmitq_chain(&mut chain).unwrap_err(),
+            Error::WriteToOutputFailed(GuestMemoryError::InvalidGuestAddress(GuestAddress(
+                0x0001_0000
+            )))
+        );
+
+        // Test normal functionality.
+        let v = vec![
+            Descriptor::new(0x3000, INPUT_SIZE, 0, 0),
+            Descriptor::new(0x4000, INPUT_SIZE, 0, 0),
+        ];
+        let mut chain = queue.build_desc_chain(&v[..2]).unwrap();
+        mem.write_slice(
+            &vec![INPUT_VALUE; INPUT_SIZE as usize],
+            GuestAddress(0x3000),
+        )
+        .unwrap();
+        mem.write_slice(
+            &vec![INPUT_VALUE * 2; INPUT_SIZE as usize],
+            GuestAddress(0x4000),
+        )
+        .unwrap();
+        console.output.clear();
+        console.process_transmitq_chain(&mut chain).unwrap();
+        assert_eq!(
+            console.output[..INPUT_SIZE as usize],
+            vec![INPUT_VALUE; INPUT_SIZE as usize]
+        );
+        assert_eq!(
+            console.output[INPUT_SIZE as usize..],
+            vec![INPUT_VALUE * 2; INPUT_SIZE as usize]
+        );
+    }
+
+    #[test]
+    fn test_process_receiveq_chain() {
+        let buf = &mut [0u8; INPUT_SIZE as usize];
+        let console = Console::new_with_capacity(DEFAULT_CAPACITY, Vec::new()).unwrap();
+
+        console
+            .enqueue_data(&mut vec![INPUT_VALUE; INPUT_SIZE as usize])
+            .unwrap();
+
+        let mem: GuestMemoryMmap =
+            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x0001_0000)]).unwrap();
+
+        // One descriptor is read only
+        let v = vec![
+            Descriptor::new(0x1000, 0x10, VIRTQ_DESC_F_WRITE, 0),
+            Descriptor::new(0x2000, INPUT_SIZE, 0, 0),
+        ];
+
+        let queue = MockSplitQueue::new(&mem, 16);
+        // The `build_desc_chain` function will populate the `NEXT` related flags and field.
+        let mut chain = queue.build_desc_chain(&v[..2]).unwrap();
+        assert_eq!(
+            console.process_receiveq_chain(&mut chain).unwrap_err(),
+            Error::UnexpectedReadOnlyDescriptor
+        );
+
+        // Descriptor is out of memory bounds
+        let v = vec![
+            Descriptor::new(0x0001_0000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0),
+            Descriptor::new(0x0002_0000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0),
+        ];
+
+        let queue = MockSplitQueue::new(&mem, 16);
+        let mut chain = queue.build_desc_chain(&v[..2]).unwrap();
+        assert_eq!(
+            console.process_receiveq_chain(&mut chain).unwrap_err(),
+            Error::WriteToGuestFailed(GuestMemoryError::InvalidGuestAddress(GuestAddress(
+                0x0001_0000
+            )))
+        );
+
+        // Test normal functionality
+        console.clear_input_buffer();
+        console
+            .enqueue_data(&mut vec![INPUT_VALUE; INPUT_SIZE as usize])
+            .unwrap();
+        console
+            .enqueue_data(&mut vec![INPUT_VALUE * 2; INPUT_SIZE as usize])
+            .unwrap();
+        let v = vec![
+            Descriptor::new(0x3000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0),
+            Descriptor::new(0x4000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0),
+        ];
+
+        let queue = MockSplitQueue::new(&mem, 16);
+        let mut chain = queue.build_desc_chain(&v[..2]).unwrap();
+        assert_eq!(
+            console.process_receiveq_chain(&mut chain).unwrap(),
+            2 * INPUT_SIZE
+        );
+
+        mem.read_slice(buf, GuestAddress(0x3000)).unwrap();
+        assert_eq!(buf, &mut [INPUT_VALUE; INPUT_SIZE as usize]);
+
+        mem.read_slice(buf, GuestAddress(0x4000)).unwrap();
+        assert_eq!(buf, &mut [INPUT_VALUE * 2; INPUT_SIZE as usize]);
+
+        // Cannot write all the content of input buffer into guest memory
+        console.clear_input_buffer();
+        console
+            .enqueue_data(&mut vec![INPUT_VALUE; 2 * INPUT_SIZE as usize])
+            .unwrap();
+        let v = vec![Descriptor::new(0x5000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0)];
+
+        let queue = MockSplitQueue::new(&mem, 16);
+        let mut chain = queue.build_desc_chain(&v[..1]).unwrap();
+
+        assert_eq!(
+            console.process_receiveq_chain(&mut chain).unwrap(),
+            INPUT_SIZE
+        );
+
+        mem.read_slice(buf, GuestAddress(0x5000)).unwrap();
+        assert_eq!(buf, &mut [INPUT_VALUE; INPUT_SIZE as usize]);
+
+        assert!(!console.is_input_buffer_empty());
+
+        let v = vec![Descriptor::new(0x6000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0)];
+        let mut chain = queue.build_desc_chain(&v[..1]).unwrap();
+
+        assert_eq!(
+            console.process_receiveq_chain(&mut chain).unwrap(),
+            INPUT_SIZE
+        );
+
+        mem.read_slice(buf, GuestAddress(0x6000)).unwrap();
+        assert_eq!(buf, &mut [INPUT_VALUE; INPUT_SIZE as usize]);
+
+        assert!(console.is_input_buffer_empty());
+
+        // Input buffer is empty.
+        let v = vec![Descriptor::new(0x7000, INPUT_SIZE, VIRTQ_DESC_F_WRITE, 0)];
+        let mut chain = queue.build_desc_chain(&v[..1]).unwrap();
+
+        assert_eq!(console.process_receiveq_chain(&mut chain).unwrap(), 0);
     }
 }

--- a/crates/devices/virtio-console/src/lib.rs
+++ b/crates/devices/virtio-console/src/lib.rs
@@ -1,0 +1,8 @@
+
+//! A crate that provides console device specific components as described
+//! by the virtio specification.
+
+#![deny(missing_docs)]
+
+/// Console module
+pub mod console;

--- a/crates/devices/virtio-console/src/lib.rs
+++ b/crates/devices/virtio-console/src/lib.rs
@@ -1,8 +1,11 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 //! A crate that provides console device specific components as described
 //! by the virtio specification.
 
 #![deny(missing_docs)]
 
-/// Console module
+/// Contains an abstraction for the virtio console descriptor chain handling.
 pub mod console;

--- a/crates/devices/virtio-console/src/lib.rs
+++ b/crates/devices/virtio-console/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
@@ -7,5 +7,5 @@
 
 #![deny(missing_docs)]
 
-/// Contains an abstraction for the virtio console descriptor chain handling.
+/// Provides an abstraction for the virtio console descriptor chain handling.
 pub mod console;


### PR DESCRIPTION
Handles the queue chain processing for the virtio console device.

Signed-off-by: Niculae Radu <r.niculae99@gmail.com>

### Summary of the PR

This is part of the virtio console implementation.
The purpose of this component is to process the queue chains and
to implement additional features (for example resize). The features
are not yet implemented. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
