### PR TITLE
Prepare releasing virtio-vsock v0.1.0 

### DIFF
--- a/crates/devices/virtio-vsock/CHANGELOG.md
+++ b/crates/devices/virtio-vsock/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.1.0
+
+This is the first release of the crate.

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -10,9 +10,10 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-virtio-queue = { path = "../../virtio-queue" }
+# The `path` part gets stripped when publishing the crate.
+virtio-queue = { path = "../../virtio-queue", version = ">=0.3.0" }
 vm-memory = ">=0.8.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }
+virtio-queue = { path = "../../virtio-queue", version = ">=0.3.0", features = ["test-utils"] }
 vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
Created the initial changelog line and added a few small adjustments to the `Cargo.toml` file for `virtio-vsock`.