### PR TITLE
Update documentation of avail_idx & used_idx

### DIFF
--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -155,11 +155,19 @@ pub trait QueueStateT: for<'a> QueueStateGuard<'a> {
     fn set_event_idx(&mut self, enabled: bool);
 
     /// Read the `idx` field from the available ring.
+    ///
+    /// # Panics
+    ///
+    /// Panics if order is Release or AcqRel.
     fn avail_idx<M>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error>
     where
         M: GuestMemory + ?Sized;
 
     /// Read the `idx` field from the used ring.
+    ///
+    /// # Panics
+    ///
+    /// Panics if order is Release or AcqRel.
     fn used_idx<M: GuestMemory>(&self, mem: &M, order: Ordering) -> Result<Wrapping<u16>, Error>;
 
     /// Put a used descriptor head into the used ring.


### PR DESCRIPTION
### Summary of the PR

The `avail_idx` and `used_idx` methods panic if the ordering is not the right one. As checking the ordering incurs a performance degradation, the VMM will be responsible for calling these functions only with the right ordering. We're now making this panic explicit by adding it to the public documentation.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
