### PR TITLE
Fix some regressions from #170

### DIFF
--- a/crates/virtio-queue/src/defs.rs
+++ b/crates/virtio-queue/src/defs.rs
@@ -13,6 +13,9 @@ pub(crate) const VIRTQ_USED_RING_HEADER_SIZE: u64 = 4;
 /// VIRTQ_USED_RING_META_SIZE + VIRTQ_USED_ELEMENT_SIZE * queue_size.
 pub(crate) const VIRTQ_USED_RING_META_SIZE: u64 = VIRTQ_USED_RING_HEADER_SIZE + 2;
 
+/// Size of one element in the used ring, id (le32) + len (le32).
+pub(crate) const VIRTQ_USED_ELEMENT_SIZE: u64 = 8;
+
 /// Size of available ring header: flags(u16) + idx(u16)
 pub(crate) const VIRTQ_AVAIL_RING_HEADER_SIZE: u64 = 4;
 
@@ -21,6 +24,9 @@ pub(crate) const VIRTQ_AVAIL_RING_HEADER_SIZE: u64 = 4;
 /// The total size of the available ring is:
 /// VIRTQ_AVAIL_RING_META_SIZE + VIRTQ_AVAIL_ELEMENT_SIZE * queue_size.
 pub(crate) const VIRTQ_AVAIL_RING_META_SIZE: u64 = VIRTQ_AVAIL_RING_HEADER_SIZE + 2;
+
+/// Size of one element in the available ring (le16).
+pub(crate) const VIRTQ_AVAIL_ELEMENT_SIZE: u64 = 2;
 
 /// Default guest physical address for descriptor table.
 pub(crate) const DEFAULT_DESC_TABLE_ADDR: u64 = 0x0;

--- a/crates/virtio-queue/src/iterator.rs
+++ b/crates/virtio-queue/src/iterator.rs
@@ -16,8 +16,7 @@ use std::sync::atomic::Ordering;
 
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
 
-use crate::defs::VIRTQ_AVAIL_RING_HEADER_SIZE;
-use virtio_bindings::bindings::virtio_ring::VRING_AVAIL_ALIGN_SIZE;
+use crate::defs::{VIRTQ_AVAIL_ELEMENT_SIZE, VIRTQ_AVAIL_RING_HEADER_SIZE};
 
 use crate::{error, DescriptorChain, QueueState};
 
@@ -151,8 +150,8 @@ where
 
         // These two operations can not overflow an u64 since they're working with relatively small
         // numbers compared to u64::MAX.
-        let elem_off = u64::from(self.next_avail.0.checked_rem(self.queue_size)?)
-            * VRING_AVAIL_ALIGN_SIZE as u64;
+        let elem_off =
+            u64::from(self.next_avail.0.checked_rem(self.queue_size)?) * VIRTQ_AVAIL_ELEMENT_SIZE;
         let offset = VIRTQ_AVAIL_RING_HEADER_SIZE + elem_off;
 
         let addr = self.avail_ring.checked_add(offset)?;

--- a/crates/virtio-queue/src/mock.rs
+++ b/crates/virtio-queue/src/mock.rs
@@ -11,12 +11,10 @@ use vm_memory::{
     Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestUsize,
 };
 
-use crate::defs::VIRTQ_AVAIL_RING_HEADER_SIZE;
+use crate::defs::{VIRTQ_AVAIL_ELEMENT_SIZE, VIRTQ_AVAIL_RING_HEADER_SIZE};
 use crate::{Descriptor, DescriptorChain, Queue, QueueState, VirtqUsedElem};
 use std::fmt::{self, Debug, Display};
-use virtio_bindings::bindings::virtio_ring::{
-    VRING_AVAIL_ALIGN_SIZE, VRING_DESC_F_INDIRECT, VRING_DESC_F_NEXT,
-};
+use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_INDIRECT, VRING_DESC_F_NEXT};
 
 /// Mock related errors.
 #[derive(Debug)]
@@ -466,7 +464,7 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
                         i,
                         self.avail_addr().unchecked_add(
                             VIRTQ_AVAIL_RING_HEADER_SIZE
-                                + (avail_idx + new_entries) as u64 * VRING_AVAIL_ALIGN_SIZE as u64,
+                                + (avail_idx + new_entries) as u64 * VIRTQ_AVAIL_ELEMENT_SIZE,
                         ),
                     )
                     .unwrap();

--- a/crates/virtio-queue/src/state.rs
+++ b/crates/virtio-queue/src/state.rs
@@ -15,16 +15,14 @@ use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
 
 use crate::defs::{
     DEFAULT_AVAIL_RING_ADDR, DEFAULT_DESC_TABLE_ADDR, DEFAULT_USED_RING_ADDR,
-    VIRTQ_AVAIL_RING_HEADER_SIZE, VIRTQ_AVAIL_RING_META_SIZE, VIRTQ_USED_RING_HEADER_SIZE,
-    VIRTQ_USED_RING_META_SIZE,
+    VIRTQ_AVAIL_ELEMENT_SIZE, VIRTQ_AVAIL_RING_HEADER_SIZE, VIRTQ_AVAIL_RING_META_SIZE,
+    VIRTQ_USED_ELEMENT_SIZE, VIRTQ_USED_RING_HEADER_SIZE, VIRTQ_USED_RING_META_SIZE,
 };
 use crate::{
     error, AvailIter, Descriptor, DescriptorChain, Error, QueueStateGuard, QueueStateOwnedT,
     QueueStateT, VirtqUsedElem,
 };
-use virtio_bindings::bindings::virtio_ring::{
-    VRING_AVAIL_ALIGN_SIZE, VRING_USED_ALIGN_SIZE, VRING_USED_F_NO_NOTIFY,
-};
+use virtio_bindings::bindings::virtio_ring::VRING_USED_F_NO_NOTIFY;
 
 /// Struct to maintain information and manipulate state of a virtio queue.
 ///
@@ -81,7 +79,7 @@ impl QueueState {
         // This can not overflow an u64 since it is working with relatively small numbers compared
         // to u64::MAX.
         let avail_event_offset =
-            VIRTQ_USED_RING_HEADER_SIZE + VRING_USED_ALIGN_SIZE as u64 * u64::from(self.size);
+            VIRTQ_USED_RING_HEADER_SIZE + VIRTQ_USED_ELEMENT_SIZE * u64::from(self.size);
         let addr = self
             .used_ring
             .checked_add(avail_event_offset)
@@ -139,7 +137,7 @@ impl QueueState {
         // This can not overflow an u64 since it is working with relatively small numbers compared
         // to u64::MAX.
         let used_event_offset =
-            VIRTQ_AVAIL_RING_HEADER_SIZE + u64::from(self.size) * VRING_AVAIL_ALIGN_SIZE as u64;
+            VIRTQ_AVAIL_RING_HEADER_SIZE + u64::from(self.size) * VIRTQ_AVAIL_ELEMENT_SIZE;
         let used_event_addr = self
             .avail_ring
             .checked_add(used_event_offset)
@@ -181,10 +179,9 @@ impl QueueStateT for QueueState {
         let avail_ring = self.avail_ring;
         // The operations below can not overflow an u64 since they're working with relatively small
         // numbers compared to u64::MAX.
-        let avail_ring_size =
-            VIRTQ_AVAIL_RING_META_SIZE + VRING_AVAIL_ALIGN_SIZE as u64 * queue_size;
+        let avail_ring_size = VIRTQ_AVAIL_RING_META_SIZE + VIRTQ_AVAIL_ELEMENT_SIZE * queue_size;
         let used_ring = self.used_ring;
-        let used_ring_size = VIRTQ_USED_RING_META_SIZE + VRING_USED_ALIGN_SIZE as u64 * queue_size;
+        let used_ring_size = VIRTQ_USED_RING_META_SIZE + VIRTQ_USED_ELEMENT_SIZE * queue_size;
 
         if !self.ready {
             error!("attempt to use virtio queue that is not marked ready");
@@ -348,7 +345,7 @@ impl QueueStateT for QueueState {
         let next_used_index = u64::from(self.next_used.0 % self.size);
         // This can not overflow an u64 since it is working with relatively small numbers compared
         // to u64::MAX.
-        let offset = VIRTQ_USED_RING_HEADER_SIZE + next_used_index * VRING_USED_ALIGN_SIZE as u64;
+        let offset = VIRTQ_USED_RING_HEADER_SIZE + next_used_index * VIRTQ_USED_ELEMENT_SIZE;
         let addr = self
             .used_ring
             .checked_add(offset)


### PR DESCRIPTION
### Summary of the PR

While testing the virtio-console in vmm-reference, @RaduNiculae noticed that the vm
was no longer booting with the latest upstream. This was caused by some bugs
introduced in https://github.com/rust-vmm/vm-virtio/pull/170.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
