### PR TITLE
Update vm-memory to 0.9.0

### DIFF
--- a/crates/devices/virtio-blk/Cargo.toml
+++ b/crates/devices/virtio-blk/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 backend-stdio = []
 
 [dependencies]
-vm-memory = ">=0.8.0"
+vm-memory = ">=0.9.0"
 vmm-sys-util = ">=0.8.0"
 log = ">=0.4.6"
 virtio-queue = { path = "../../virtio-queue" }
@@ -21,5 +21,5 @@ virtio-device = { path = "../../virtio-device" }
 virtio-bindings = { path = "../../virtio-bindings", version = ">=0.1.0" }
 
 [dev-dependencies]
-vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = ">=0.9.0", features = ["backend-mmap", "backend-atomic"] }
 virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }

--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -14,4 +14,4 @@ edition = "2021"
 [dependencies]
 virtio-bindings = { path = "../../virtio-bindings", version = ">=0.1.0" }
 virtio-queue = { path = "../../virtio-queue", version = ">=0.3.0" }
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 # The `path` part gets stripped when publishing the crate.
 virtio-queue = { path = "../../virtio-queue", version = ">=0.3.0" }
 virtio-bindings = { path = "../../virtio-bindings", version = ">=0.1.0" }
-vm-memory = ">=0.8.0"
+vm-memory = ">=0.9.0"
 
 [dev-dependencies]
 virtio-queue = { path = "../../virtio-queue", version = ">=0.3.0", features = ["test-utils"] }
-vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = ">=0.9.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-device/Cargo.toml
+++ b/crates/virtio-device/Cargo.toml
@@ -10,9 +10,9 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 
 [dependencies]
-vm-memory = ">=0.8.0"
+vm-memory = ">=0.9.0"
 log = ">=0.4.6"
 virtio-queue = { path = "../virtio-queue" }
 
 [dev-dependencies]
-vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = ">=0.9.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -15,4 +15,4 @@ versionize = "0.1.6"
 versionize_derive = "0.1.3"
 # The `path` part gets stripped when publishing the crate.
 virtio-queue = { path = "../../crates/virtio-queue", version = "0.5.0" }
-vm-memory = "0.8.0"
+vm-memory = "0.9.0"

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2018"
 test-utils = []
 
 [dependencies]
-vm-memory = "^0.8.0"
+vm-memory = "^0.9.0"
 vmm-sys-util = "^0.10.0"
 log = "^0.4.6"
 virtio-bindings = { path="../virtio-bindings", version = "^0.1.0" }
 
 [dev-dependencies]
 criterion = "0.3.0"
-vm-memory = { version = "^0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "^0.9.0", features = ["backend-mmap", "backend-atomic"] }
 memoffset = "~0"
 
 [[bench]]


### PR DESCRIPTION
This updates vm-memory to version 0.9.0.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>