### PR TITLE
Cleanup of README + alphabetical order of crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 members = [
+    "crates/devices/*",
+    "crates/virtio-bindings",
+    "crates/virtio-device",
     "crates/virtio-queue",
     "crates/virtio-queue-ser",
-    "crates/virtio-device",
-    "crates/devices/*",
-    "crates/virtio-bindings"
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@ The `vm-virtio` workspace provides
 abstractions and implementation for the virtio queue and devices. For now, it
 consists of the following crates:
 
+- `virtio-bindings` -> provides Rust FFI bindings to the corresponding Linux 
+  kernel API;
+- `virtio-blk` -> contains abstractions for parsing and executing a request of
+  the block device;
+- `virtio-console` -> contains abstractions for the virtio console device;
+- `virtio-device` -> provides abstractions for the common functionality of the
+  virtio devices, and a default implementation for the MMIO
+  transport operations (read, write);
 - `virtio-queue` -> provides a virtio device implementation for a virtio queue,
                     a virtio descriptor and a chain of such descriptors;
-- `virtio-device` -> provides abstractions for the common functionality of the
-                     virtio devices, and a default implementation for the MMIO
-                     transport operations (read, write);
-- `virtio-blk` -> contains abstractions for parsing and executing a request of
-                  the block device.
+- `virtio-queue-ser` -> provides abstractions for serialization and 
+   deserialization for virtio queue states;
 - `virtio-vsock` -> provides an implementation for the vsock packet.
 
 ### Note


### PR DESCRIPTION
### Summary of the PR

At my company Cyberus Technology, we think about upstreaming certain functionality. As preparation and to get familiar with the code base and the contribution process, here is a first PR. It synchronizes the README with the crates of this repository and orders all crates alphabetically.

btw: I noticed that some things seem to be unmaintained or unused. For example:
- `virtio-device` is not on crates.io 
- `virtio-devices` is on crates.io but its GitHub repository doesn't exist
- `virtio-console` is not on crates.io

Any comments on those?

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] ~All added/changed functionality has a corresponding unit/integration
  test.~
- [ ] ~Any newly added `unsafe` code is properly documented.~
