### PR TITLE
virtio-queue: Error out early on invalid available ring index

### DIFF
--- a/crates/virtio-queue/src/lib.rs
+++ b/crates/virtio-queue/src/lib.rs
@@ -63,6 +63,8 @@ pub enum Error {
     InvalidAvailRingAlign,
     /// Invalid alignment of used ring address.
     InvalidUsedRingAlign,
+    /// Invalid available ring index.
+    InvalidAvailRingIndex,
 }
 
 impl Display for Error {
@@ -89,6 +91,10 @@ impl Display for Error {
             InvalidUsedRingAlign => {
                 write!(f, "virtio queue used ring breaks alignment constraints")
             }
+            InvalidAvailRingIndex => write!(
+                f,
+                "invalid available ring index (more descriptors to process than queue size)"
+            ),
         }
     }
 }


### PR DESCRIPTION
The number of descriptor chain heads to process should always be smaller or equal to the queue size, as the driver should never ask the VMM to process a available ring entry more than once. Checking and reporting such incorrect driver behavior can avoid potential hanging and Denial-of-Service from VMMs.

Signed-off-by: Bo Chen <chen.bo@intel.com>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
