### PR TITLE
Update vm-memory, vmm-sys-util and virtio-queue + release

### DIFF
--- a/crates/devices/virtio-blk/Cargo.toml
+++ b/crates/devices/virtio-blk/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2021"
 backend-stdio = []
 
 [dependencies]
-vm-memory = "0.9.0"
-vmm-sys-util = "0.10.0"
+vm-memory = "0.10.0"
+vmm-sys-util = "0.11.0"
 log = "0.4.17"
 virtio-queue = { path = "../../virtio-queue" }
 virtio-device = { path = "../../virtio-device" }
 virtio-bindings = { path = "../../virtio-bindings", version = "0.1.0" }
 
 [dev-dependencies]
-vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
 virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }

--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2021"
 
 [dependencies]
 virtio-bindings = { path = "../../virtio-bindings", version = "0.1.0" }
-virtio-queue = { path = "../../virtio-queue", version = "0.6.0" }
-vm-memory = "0.9.0"
+virtio-queue = { path = "../../virtio-queue", version = "0.7.0" }
+vm-memory = "0.10.0"

--- a/crates/devices/virtio-vsock/CHANGELOG.md
+++ b/crates/devices/virtio-vsock/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.2.0
+
+## Added
+
+- Derive `Eq` for `packet::PacketHeader`.
+
+## Changes
+
+- Updated vm-memory to 0.10.0.
+- Updated virtio-queue to 0.7.0.
+- Upgrade Rust edition to 2021.
+
 # v0.1.0
 
 This is the first release of the crate.

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-vsock"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "virtio vsock device implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 
 [dependencies]
 # The `path` part gets stripped when publishing the crate.
-virtio-queue = { path = "../../virtio-queue", version = "0.6.0" }
+virtio-queue = { path = "../../virtio-queue", version = "0.7.0" }
 virtio-bindings = { path = "../../virtio-bindings", version = "0.1.0" }
-vm-memory = "0.9.0"
+vm-memory = "0.10.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../../virtio-queue", version = "0.6.0", features = ["test-utils"] }
-vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { path = "../../virtio-queue", version = "0.7.0", features = ["test-utils"] }
+vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-device/Cargo.toml
+++ b/crates/virtio-device/Cargo.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0 OR MIT"
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.9.0"
+vm-memory = "0.10.0"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
-virtio-queue = { path = "../virtio-queue", version = "0.6.0"}
+virtio-queue = { path = "../virtio-queue", version = "0.7.0"}
 
 [dev-dependencies]
-vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-queue-ser/CHANGELOG.md
+++ b/crates/virtio-queue-ser/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.4.0
+
+## Added 
+
+- Derived `Eq` for `state::QueueStateSer`.
+
+## Changed
+- Updated vm-memory from 0.9.0 to 0.10.0.
+- Updated virtio-queue from 0.6.1 to 0.7.0 and fix version to exactly 0.7.0 to ensure the crates 
+  are always updated in lock-step.
+- Upgrade rust edition to 2021
+
 # v0.3.0
 
 ## Changed

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -14,5 +14,5 @@ serde = { version = "1.0.27", features = ["derive"] }
 versionize = "0.1.6"
 versionize_derive = "0.1.3"
 # The `path` part gets stripped when publishing the crate.
-virtio-queue = { path = "../../crates/virtio-queue", version = "0.6.0" }
-vm-memory = "0.9.0"
+virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.0" }
+vm-memory = "0.10.0"

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue-ser"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "Serialization for virtio queue state"
 repository = "https://github.com/rust-vmm/vm-virtio"
@@ -14,5 +14,8 @@ serde = { version = "1.0.27", features = ["derive"] }
 versionize = "0.1.6"
 versionize_derive = "0.1.3"
 # The `path` part gets stripped when publishing the crate.
+# We use `=0.7.0` as we maintain a 1:1-relationship between virtio-queue
+# and virtio-queue-ser releases. This is to prevent accidental changes
+# to the serializer output in a patch release of virtio-queue. 
 virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.0" }
 vm-memory = "0.10.0"

--- a/crates/virtio-queue/CHANGELOG.md
+++ b/crates/virtio-queue/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.7.0
+
+## Changed
+
+- Updated vmm-sys-util from 0.10.0 to 0.11.0.
+- Updated vm-memory from 0.9.0 to 0.10.0.
+
 # v0.6.1
 
 ## Fixed

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["The Chromium OS Authors"]
 description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -13,15 +13,15 @@ edition = "2021"
 test-utils = []
 
 [dependencies]
-vm-memory = "0.9.0"
-vmm-sys-util = "0.10.0"
+vm-memory = "0.10.0"
+vmm-sys-util = "0.11.0"
 log = "0.4.17"
 virtio-bindings = { path="../virtio-bindings", version = "0.1.0" }
 
 [dev-dependencies]
 criterion = "0.3.0"
-vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }
-memoffset = "~0"
+vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+memoffset = "0.7.1"
 
 [[bench]]
 name = "main"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.63"
 virtio-queue = { path = "../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../crates/virtio-queue-ser" }
-vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
 
 [[bin]]

--- a/fuzz/common/Cargo.toml
+++ b/fuzz/common/Cargo.toml
@@ -12,4 +12,4 @@ virtio-bindings = "0.1.0"
 virtio-queue = { path = "../../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../../crates/virtio-queue-ser" }
-vm-memory = { version = "0.9.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
### Summary of the PR

Update intra-rust-vmm dependencies to latest versions that have fixed requirements and release new versions

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
