### PR TITLE
virtio-bindings: fix bindgen install instructions

### DIFF
--- a/crates/virtio-bindings/CONTRIBUTING.md
+++ b/crates/virtio-bindings/CONTRIBUTING.md
@@ -4,9 +4,9 @@
 
 ### Bindgen
 The bindings are currently generated using
-[bindgen](https://crates.io/crates/bindgen) version 0.61.0:
+[bindgen](https://rust-lang.github.io/rust-bindgen/) version 0.61.0:
 ```bash
-cargo install bindgen --vers 0.61.0
+cargo install bindgen-cli --vers 0.61.0
 ```
 
 ### Linux Kernel


### PR DESCRIPTION
### Summary of the PR

The bindgen CLI was recently extracted to its own crate.  When I updated the bindgen version, I didn't realise the cargo installation instructions needed to be changed.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
