### PR TITLE
Enable features required for tests

### DIFF
--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -15,3 +15,7 @@ edition = "2021"
 virtio-bindings = { path = "../../virtio-bindings", version = "0.1.0" }
 virtio-queue = { path = "../../virtio-queue", version = "0.7.0" }
 vm-memory = "0.10.0"
+
+[dev-dependencies]
+virtio-queue = { path = "../../virtio-queue", version = "0.7.0", features = ["test-utils"] }
+vm-memory = { version = "0.10.0", features = ["backend-mmap"] }

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -19,3 +19,6 @@ versionize_derive = "0.1.3"
 # to the serializer output in a patch release of virtio-queue. 
 virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.0" }
 vm-memory = "0.10.0"
+
+[dev-dependencies]
+virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.0", features = ["test-utils"] }


### PR DESCRIPTION
### Summary of the PR

`cargo test` works, but due to how cargo enables features for crates built in a workspace, this is by accident, and the following commands fail without this patch:

- Fixes `cargo test -p virtio-console`
- Fixes `cargo test -p virtio-queue-ser`

These changes are modeled after the dev-dependencies that already exist to enable these features in e.g. virtio-vsock: 

https://github.com/rust-vmm/vm-virtio/blob/c527b45dada0a81d343aca7f06759d5637d6429a/crates/devices/virtio-vsock/Cargo.toml#L18-L20

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [n/a] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [n/a] Any newly added `unsafe` code is properly documented.
