### PR TITLE
virtio-queue: fix alignment check for indirect descriptor

### DIFF
--- a/crates/virtio-queue/CHANGELOG.md
+++ b/crates/virtio-queue/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fixed
+- Skip indirect descriptor address alignment check, the virtio spec has
+  no alignment requirement on this, see `2.6.5.3 Indirect Descriptors`
+  and `2.7.7 Indirect Flag: Scatter-Gather Support` in virtio 1.0.
+
 # v0.7.0
 
 ## Changed


### PR DESCRIPTION
see also: https://gitlab.com/virtio-fs/virtiofsd/-/issues/74

With specific guest kernel config, virtiofsd run panic with cloud-hypervisor, because address of indirect descriptor table is not proper aligned.

After read the spec, there should no restrict on address of indirect descriptor:

    2.6.5 The Virtqueue Descriptor Table
    ...
    To increase ring capacity the driver can store a table
    of indirect descriptors anywhere in memory, and insert
    a descriptor in main virtqueue (with
    flags&VIRTQ_DESC_F_INDIRECT on) that refers to memory
    buffer containing this indirect descriptor table.



### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
