### PR TITLE
virtio-queue: fix endianess issues in mock queue

### DIFF
--- a/crates/virtio-queue/src/mock.rs
+++ b/crates/virtio-queue/src/mock.rs
@@ -464,7 +464,8 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
         let mut new_entries = 0;
         let avail_idx: u16 = self
             .mem
-            .read_obj(self.avail_addr().unchecked_add(2))
+            .read_obj::<u16>(self.avail_addr().unchecked_add(2))
+            .map(u16::from_le)
             .unwrap();
 
         for (idx, desc) in descs.iter().enumerate() {
@@ -475,7 +476,7 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
                 // Update the available ring position.
                 self.mem
                     .write_obj(
-                        i,
+                        u16::to_le(i),
                         self.avail_addr().unchecked_add(
                             VIRTQ_AVAIL_RING_HEADER_SIZE
                                 + (avail_idx + new_entries) as u64 * VIRTQ_AVAIL_ELEMENT_SIZE,
@@ -488,7 +489,10 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
 
         // Increment `avail_idx`.
         self.mem
-            .write_obj(avail_idx + new_entries, self.avail_addr().unchecked_add(2))
+            .write_obj(
+                u16::to_le(avail_idx + new_entries),
+                self.avail_addr().unchecked_add(2),
+            )
             .unwrap();
 
         Ok(())

--- a/crates/virtio-queue/src/queue.rs
+++ b/crates/virtio-queue/src/queue.rs
@@ -1284,16 +1284,16 @@ mod tests {
         // When the number of chains exposed by the driver is equal to or less than the queue
         // size, the available ring index is valid and constructs an iterator successfully.
         let avail_idx = Wrapping(q.next_avail()) + Wrapping(queue_size);
-        vq.avail().idx().store(avail_idx.0);
+        vq.avail().idx().store(u16::to_le(avail_idx.0));
         assert!(q.iter(mem).is_ok());
         let avail_idx = Wrapping(q.next_avail()) + Wrapping(queue_size - 1);
-        vq.avail().idx().store(avail_idx.0);
+        vq.avail().idx().store(u16::to_le(avail_idx.0));
         assert!(q.iter(mem).is_ok());
 
         // When the number of chains exposed by the driver is larger than the queue size, the
         // available ring index is invalid and produces an error from constructing an iterator.
         let avail_idx = Wrapping(q.next_avail()) + Wrapping(queue_size + 1);
-        vq.avail().idx().store(avail_idx.0);
+        vq.avail().idx().store(u16::to_le(avail_idx.0));
         assert!(q.iter(mem).is_err());
     }
 


### PR DESCRIPTION
Fix a couple of new endianess issues in the mock queue that impact big endian hosts (namely, s390x).

Signed-off-by: Sergio Lopez <slp@redhat.com>