### PR TITLE
release virtio-queue v0.7.1

### DIFF
--- a/crates/virtio-queue-ser/CHANGELOG.md
+++ b/crates/virtio-queue-ser/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.4.1
+- Update the virtio-queue dependency to v0.7.1. This release contains no
+  breaking changes.
+
 # v0.4.0
 
 ## Added 

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue-ser"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "Serialization for virtio queue state"
 repository = "https://github.com/rust-vmm/vm-virtio"
@@ -17,8 +17,8 @@ versionize_derive = "0.1.3"
 # We use `=0.7.0` as we maintain a 1:1-relationship between virtio-queue
 # and virtio-queue-ser releases. This is to prevent accidental changes
 # to the serializer output in a patch release of virtio-queue. 
-virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.0" }
+virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.1" }
 vm-memory = "0.10.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.0", features = ["test-utils"] }
+virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.1", features = ["test-utils"] }

--- a/crates/virtio-queue/CHANGELOG.md
+++ b/crates/virtio-queue/CHANGELOG.md
@@ -2,6 +2,13 @@
 - Skip indirect descriptor address alignment check, the virtio spec has
   no alignment requirement on this, see `2.6.5.3 Indirect Descriptors`
   and `2.7.7 Indirect Flag: Scatter-Gather Support` in virtio 1.0.
+- Update the `add_desc_chains` mock function such that it works on big endian
+  hosts as well.
+- Check that the queue is ready for processing requests when calling the
+  iterator functions. For now the checks are limited to the avail address and
+  the ready fields, but should be extended in the future to account for other
+  fields that could signal an invalid queue. This behavior can be triggered
+  by doing a `reset` followed by a `pop_descriptor_chain`.
 
 # v0.7.0
 

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["The Chromium OS Authors"]
 description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
### Summary of the PR

This is a patch release that fixes endianess and the problems with the iterator. In this release we did not update to the latest virtio-bindings version as that would result in a big change. This could cause other problems that would make it hard to consume this otherwise important patch release.

Note that when building locally virtio-queue the latests virtio-bindings will be used, but in production use cases this will not be the case because the v0.1.0 virtio-bindings will be used from crates.io.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
