### PR TITLE
fuzz: iterate only over descriptor chains

### DIFF
--- a/fuzz/common/src/lib.rs
+++ b/fuzz/common/src/lib.rs
@@ -156,18 +156,16 @@ impl VirtioQueueFunction {
             // the Queue function `pop_descriptor_chain` in a loop as this is the way
             // descriptors are typically processed.
             _PopDescriptorChainLoop => {
-                while let Some(mut desc_chain) = q.pop_descriptor_chain(m) {
+                while let Some(_desc_chain) = q.pop_descriptor_chain(m) {
                     // this empty loop is here to check that there are no side effects
                     // in terms of memory & execution time.
-                    while desc_chain.next().is_some() {}
                 }
             }
             Iter => {
-                let _ = q.iter(m).and_then(|mut i| {
+                let _ = q.iter(m).map(|_| {
                     // this empty loop is here to check that there are no side effects
                     // in terms of memory & execution time.
-                    while i.next().is_some() {}
-                    Ok(())
+                    ()
                 });
             }
         }


### PR DESCRIPTION
### Summary of the PR

We were iterating over both descriptor chains, and descriptors in a chain. This was triggering a timeout when running the fuzzer. When implementing a device though, this timeout should not happen because the device implementation must make sure to only retrieve as many descriptor chains as it needed. This cannot be addressed at the queue abstraction level.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
