### PR TITLE
virtio-queue: do not iterate over more than 2^32 bytes

### DIFF
--- a/crates/virtio-queue/CHANGELOG.md
+++ b/crates/virtio-queue/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming Release
+
+## Changed
+- Terminate iterating descriptor chains that are longer than 2^32 bytes.
+
 # v0.7.1
 
 ## Fixed


### PR DESCRIPTION
When fuzzing a SCSI vhost-user device, the fuzzer invented a (rather large) self referential descriptor. virtio-scsi then requires reporting the "residual" bytes, which when summing up the remaining bytes can overflow 2^32 bytes. Since the spec mandates that descriptor chains must not exceed 2^32 bytes, let's just terminate iteration once we overrun.

The tests demonstrate how the overflows happened before. While virtio-queue does not directly suffer from any consequences, this guards consumers from having to handle this on their own.


Link: https://rust-vmm.slack.com/archives/CFH3R8PFV/p1682002847952759

### Summary of the PR

Terminate iterating over a descriptor chain that is longer than 2^32 bytes.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
