### PR TITLE
Bulk update vm-memory to 0.11.0

### DIFF
--- a/crates/devices/virtio-blk/Cargo.toml
+++ b/crates/devices/virtio-blk/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 backend-stdio = []
 
 [dependencies]
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 vmm-sys-util = "0.11.0"
 log = "0.4.17"
 virtio-queue = { path = "../../virtio-queue" }
@@ -21,5 +21,5 @@ virtio-device = { path = "../../virtio-device" }
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.0" }
 
 [dev-dependencies]
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }

--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.0" }
 virtio-queue = { path = "../../virtio-queue", version = "0.7.0" }
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 
 [dev-dependencies]
 virtio-queue = { path = "../../virtio-queue", version = "0.7.0", features = ["test-utils"] }
-vm-memory = { version = "0.10.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap"] }

--- a/crates/devices/virtio-vsock/CHANGELOG.md
+++ b/crates/devices/virtio-vsock/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming release
+
+## Changes
+
+- Updated vm-memory from 0.10.0 to 0.11.0.
+
 # v0.2.1
 
 ## Changes

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 # The `path` part gets stripped when publishing the crate.
 virtio-queue = { path = "../../virtio-queue", version = "0.7.0" }
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.0" }
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 
 [dev-dependencies]
 virtio-queue = { path = "../../virtio-queue", version = "0.7.0", features = ["test-utils"] }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-bindings/CHANGELOG.md
+++ b/crates/virtio-bindings/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Regenerate bindings with Linux 6.3.
 - Added bindings for virtio_scsi.h
+- Updated vm-memory from 0.10.0 to 0.11.0.
 
 # v0.2.0
 

--- a/crates/virtio-device/Cargo.toml
+++ b/crates/virtio-device/Cargo.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0 OR MIT"
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
 virtio-queue = { path = "../virtio-queue", version = "0.7.0"}
 
 [dev-dependencies]
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-queue-ser/CHANGELOG.md
+++ b/crates/virtio-queue-ser/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Upcoming release
+
+## Changed
+
+- Updated vm-memory from 0.10.0 to 0.11.0.
+
 # v0.4.1
 - Update the virtio-queue dependency to v0.7.1. This release contains no
   breaking changes.

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -18,7 +18,7 @@ versionize_derive = "0.1.3"
 # and virtio-queue-ser releases. This is to prevent accidental changes
 # to the serializer output in a patch release of virtio-queue. 
 virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.1" }
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 
 [dev-dependencies]
 virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.1", features = ["test-utils"] }

--- a/crates/virtio-queue/CHANGELOG.md
+++ b/crates/virtio-queue/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Changed
 - Terminate iterating descriptor chains that are longer than 2^32 bytes.
+- Updated vm-memory from 0.10.0 to 0.11.0.
+- Updated virtio-bindings from 0.1.0 to 0.2.0.
 
 # v0.7.1
 

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2021"
 test-utils = []
 
 [dependencies]
-vm-memory = "0.10.0"
+vm-memory = "0.11.0"
 vmm-sys-util = "0.11.0"
 log = "0.4.17"
 virtio-bindings = { path="../virtio-bindings", version = "0.2.0" }
 
 [dev-dependencies]
 criterion = "0.3.0"
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 memoffset = "0.7.1"
 
 [[bench]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.63"
 virtio-queue = { path = "../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../crates/virtio-queue-ser" }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
 
 [[bin]]

--- a/fuzz/common/Cargo.toml
+++ b/fuzz/common/Cargo.toml
@@ -12,4 +12,4 @@ virtio-bindings = "0.1.0"
 virtio-queue = { path = "../../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../../crates/virtio-queue-ser" }
-vm-memory = { version = "0.10.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
We need to update all projects at once to avoid breaking the ability to run "cargo test" from the root of the workspace.
