### PR TITLE
virtio-queue-0.8.0 and virtio-queue-ser-0.5.0

### DIFF
--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2021"
 
 [dependencies]
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.0" }
-virtio-queue = { path = "../../virtio-queue", version = "0.7.0" }
+virtio-queue = { path = "../../virtio-queue", version = "0.8.0" }
 vm-memory = "0.11.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../../virtio-queue", version = "0.7.0", features = ["test-utils"] }
+virtio-queue = { path = "../../virtio-queue", version = "0.8.0", features = ["test-utils"] }
 vm-memory = { version = "0.11.0", features = ["backend-mmap"] }

--- a/crates/devices/virtio-vsock/CHANGELOG.md
+++ b/crates/devices/virtio-vsock/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Changes
 
 - Updated vm-memory from 0.10.0 to 0.11.0.
+- Updated virtio-queue from 0.7.0 to 0.8.0.
 
 # v0.2.1
 

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 
 [dependencies]
 # The `path` part gets stripped when publishing the crate.
-virtio-queue = { path = "../../virtio-queue", version = "0.7.0" }
+virtio-queue = { path = "../../virtio-queue", version = "0.8.0" }
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.0" }
 vm-memory = "0.11.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../../virtio-queue", version = "0.7.0", features = ["test-utils"] }
+virtio-queue = { path = "../../virtio-queue", version = "0.8.0", features = ["test-utils"] }
 vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-device/Cargo.toml
+++ b/crates/virtio-device/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 vm-memory = "0.11.0"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
-virtio-queue = { path = "../virtio-queue", version = "0.7.0"}
+virtio-queue = { path = "../virtio-queue", version = "0.8.0"}
 
 [dev-dependencies]
 vm-memory = { version = "0.11.0", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-queue-ser/CHANGELOG.md
+++ b/crates/virtio-queue-ser/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Upcoming release
 
+# v0.5.0
+
 ## Changed
 
 - Updated vm-memory from 0.10.0 to 0.11.0.
+- Updated virtio-queue from 0.7.1 to 0.8.0.
 
 # v0.4.1
 - Update the virtio-queue dependency to v0.7.1. This release contains no

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue-ser"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "Serialization for virtio queue state"
 repository = "https://github.com/rust-vmm/vm-virtio"
@@ -14,11 +14,11 @@ serde = { version = "1.0.27", features = ["derive"] }
 versionize = "0.1.6"
 versionize_derive = "0.1.3"
 # The `path` part gets stripped when publishing the crate.
-# We use `=0.7.0` as we maintain a 1:1-relationship between virtio-queue
+# We use `=0.8.0` as we maintain a 1:1-relationship between virtio-queue
 # and virtio-queue-ser releases. This is to prevent accidental changes
 # to the serializer output in a patch release of virtio-queue. 
-virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.1" }
+virtio-queue = { path = "../../crates/virtio-queue", version = "=0.8.0" }
 vm-memory = "0.11.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../../crates/virtio-queue", version = "=0.7.1", features = ["test-utils"] }
+virtio-queue = { path = "../../crates/virtio-queue", version = "=0.8.0", features = ["test-utils"] }

--- a/crates/virtio-queue/CHANGELOG.md
+++ b/crates/virtio-queue/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Upcoming Release
 
+# v0.8.0
+
 ## Changed
 - Terminate iterating descriptor chains that are longer than 2^32 bytes.
 - Updated vm-memory from 0.10.0 to 0.11.0.

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["The Chromium OS Authors"]
 description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
Set up the stage for releasing virtio-queue-0.8.0 by updating the version in the crate and all its references across the workspace.

Also get ready to release virtio-queue-ser-0.5.0, as it seems we want to always keep them in sync.