### PR TITLE
release virtio-vsock v0.3.0

### DIFF
--- a/crates/devices/virtio-vsock/CHANGELOG.md
+++ b/crates/devices/virtio-vsock/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Upcoming release
+# v0.3.0
 
 ## Changes
 

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-vsock"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "virtio vsock device implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
This updates vm-memory and virtio-queue crates to newer versions.