### PR TITLE
Add `virtio-blk` fuzzing target

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -42,6 +42,12 @@
       "command": "cd fuzz && cargo test --package common --lib vsock && cargo +nightly fuzz run vsock -- -max_total_time=900 -timeout=60s",
       "platform": ["x86_64", "aarch64"],
       "timeout_in_minutes": 20
+    },
+    {
+      "test_name": "fuzz-virtio-blk",
+      "command": "cd fuzz && cargo test --package common --lib blk && cargo +nightly fuzz run blk -- -max_total_time=900 -timeout=60s",
+      "platform": ["x86_64", "aarch64"],
+      "timeout_in_minutes": 20
     }
   ]
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,11 +16,13 @@ cargo-fuzz = true
 bincode = "1.3.3"
 libfuzzer-sys = "0.4"
 serde = "1.0.63"
+memfd = "0.6.3"
 virtio-queue = { path = "../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../crates/virtio-queue-ser" }
 vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
+virtio-blk = { path = "../crates/devices/virtio-blk", features = ["backend-stdio"] }
 
 [[bin]]
 name = "virtio_queue"
@@ -33,3 +35,7 @@ path = "fuzz_targets/vsock.rs"
 [[bin]]
 name = "virtio_queue_ser"
 path = "fuzz_targets/virtio_queue_ser.rs"
+
+[[bin]]
+name = "blk"
+path = "fuzz_targets/blk.rs"

--- a/fuzz/common/Cargo.toml
+++ b/fuzz/common/Cargo.toml
@@ -12,4 +12,5 @@ virtio-bindings = { path = "../../crates/virtio-bindings" }
 virtio-queue = { path = "../../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../../crates/virtio-queue-ser" }
+virtio-blk = { path = "../../crates/devices/virtio-blk" }
 vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }

--- a/fuzz/common/src/blk.rs
+++ b/fuzz/common/src/blk.rs
@@ -8,3 +8,127 @@ pub struct BlkInput {
     pub features: u64,
     pub device_id: Option<[u8; 20]>,
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::create_corpus_file;
+    use crate::virtio_queue::DEFAULT_QUEUE_SIZE;
+    use std::io::Write;
+    use std::mem;
+    use virtio_bindings::bindings::virtio_blk::VIRTIO_BLK_T_IN;
+    use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
+    use virtio_blk::request::{Request, RequestType};
+    use virtio_queue::{mock::MockSplitQueue, Descriptor};
+    use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+
+    // The same as the RequestHeader type in virtio_blk, with exposed fields
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    #[repr(C)]
+    struct FuzzingBlkRequestHdr {
+        request_type: u32,
+        _reserved: u32,
+        sector: u64,
+    }
+
+    unsafe impl ByteValued for FuzzingBlkRequestHdr {}
+
+    // Test values for the descriptor chain
+    const REQ_TYPE: u32 = VIRTIO_BLK_T_IN;
+    const REQ_SECTOR: u64 = 1;
+    const HEADER_ADDR: u64 = 0x100;
+    const HEADER_LEN: u32 = mem::size_of::<FuzzingBlkRequestHdr>() as u32;
+    const REQ_DATA_ADDRS: &[u64] = &[0x3000, 0x4000];
+    const REQ_STATUS_ADDR: u64 = 0x5000;
+    const DESC_LEN: usize = 0x1000;
+
+    #[test]
+    fn test_blk_basic_descriptor_chain() {
+        let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let vq = MockSplitQueue::new(&mem, DEFAULT_QUEUE_SIZE);
+
+        // Create header and write it to memory
+        let header = FuzzingBlkRequestHdr {
+            request_type: REQ_TYPE,
+            _reserved: 0,
+            sector: REQ_SECTOR,
+        };
+        mem.write_slice(header.as_slice(), GuestAddress(HEADER_ADDR))
+            .unwrap();
+
+        // Initialize data and status memory
+        for data_addr in REQ_DATA_ADDRS.iter().copied() {
+            mem.write_slice(&[0u8; DESC_LEN], GuestAddress(data_addr))
+                .unwrap();
+        }
+        mem.write_slice(&[0u8; DESC_LEN], GuestAddress(REQ_STATUS_ADDR))
+            .unwrap();
+
+        let descriptors = [
+            FuzzingDescriptor {
+                addr: HEADER_ADDR,
+                len: HEADER_LEN,
+                flags: VRING_DESC_F_NEXT as u16,
+                next: 1,
+            },
+            FuzzingDescriptor {
+                addr: REQ_DATA_ADDRS[0],
+                len: DESC_LEN as u32,
+                flags: (VRING_DESC_F_NEXT | VRING_DESC_F_WRITE) as u16,
+                next: 2,
+            },
+            FuzzingDescriptor {
+                addr: REQ_DATA_ADDRS[1],
+                len: DESC_LEN as u32,
+                flags: (VRING_DESC_F_NEXT | VRING_DESC_F_WRITE) as u16,
+                next: 3,
+            },
+            FuzzingDescriptor {
+                addr: REQ_STATUS_ADDR,
+                len: DESC_LEN as u32,
+                flags: VRING_DESC_F_WRITE as u16,
+                next: 0,
+            },
+        ];
+
+        let q_descriptors: Vec<Descriptor> =
+            descriptors.into_iter().map(|desc| desc.into()).collect();
+        let mut chain = vq.build_multiple_desc_chains(&q_descriptors).unwrap();
+
+        let req = Request::parse(&mut chain).unwrap();
+        let data = req.data();
+        assert_eq!(data.len(), 2);
+        assert_eq!(
+            data.get(0),
+            Some(&(GuestAddress(REQ_DATA_ADDRS[0]), DESC_LEN as u32))
+        );
+        assert_eq!(
+            data.get(1),
+            Some(&(GuestAddress(REQ_DATA_ADDRS[1]), DESC_LEN as u32))
+        );
+        assert_eq!(req.sector(), REQ_SECTOR);
+        assert_eq!(req.status_addr(), GuestAddress(REQ_STATUS_ADDR));
+        assert_eq!(
+            req.total_data_len(),
+            (DESC_LEN * REQ_DATA_ADDRS.len()) as u64
+        );
+        assert_eq!(req.request_type(), RequestType::In);
+
+        let fuzz_input = BlkInput {
+            descriptors: descriptors.to_vec(),
+            guestmem: Vec::new(),
+            features: 0,
+            device_id: Some([1; 20]),
+        };
+
+        let (mut out_file, path) = create_corpus_file("blk", "descriptor_chain");
+        out_file
+            .write_all(bincode::serialize(&fuzz_input).unwrap().as_slice())
+            .unwrap();
+
+        // Let's validate that we have in the file what we actually wrote.
+        let written_input =
+            bincode::deserialize::<BlkInput>(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(fuzz_input, written_input);
+    }
+}

--- a/fuzz/common/src/blk.rs
+++ b/fuzz/common/src/blk.rs
@@ -1,0 +1,10 @@
+use crate::FuzzingDescriptor;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct BlkInput {
+    pub descriptors: Vec<FuzzingDescriptor>,
+    pub guestmem: Vec<(u64, Vec<u8>)>,
+    pub features: u64,
+    pub device_id: Option<[u8; 20]>,
+}

--- a/fuzz/common/src/lib.rs
+++ b/fuzz/common/src/lib.rs
@@ -6,6 +6,7 @@ use vm_memory::GuestMemoryMmap;
 
 use serde::{Deserialize, Serialize};
 
+pub mod blk;
 pub mod virtio_queue;
 pub mod virtio_queue_ser;
 pub mod vsock;

--- a/fuzz/fuzz_targets/blk.rs
+++ b/fuzz/fuzz_targets/blk.rs
@@ -1,0 +1,51 @@
+#![no_main]
+
+use common::blk::BlkInput;
+use common::virtio_queue::DEFAULT_QUEUE_SIZE;
+use libfuzzer_sys::fuzz_target;
+use std::hint::black_box;
+use virtio_blk::request::Request;
+use virtio_blk::stdio_executor::StdIoBackend;
+use virtio_queue::{mock::MockSplitQueue, Descriptor};
+use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(fuzz_input) = bincode::deserialize::<BlkInput>(data) else {
+        return;
+    };
+
+    let start_addr = GuestAddress(0x1000);
+    // Create and randomly populate the guest memory
+    let m = GuestMemoryMmap::<()>::from_ranges(&[(start_addr, 0x11000)]).unwrap();
+    for (addr, mem) in fuzz_input.guestmem.iter() {
+        let _ = m.write_slice(mem, GuestAddress(*addr));
+    }
+
+    let vq = MockSplitQueue::create(&m, start_addr, DEFAULT_QUEUE_SIZE);
+
+    let descriptors: Vec<Descriptor> = fuzz_input
+        .descriptors
+        .iter()
+        .map(|desc| (*desc).into())
+        .collect();
+
+    // A backing in-memory file
+    let memfile = memfd::MemfdOptions::default()
+        .create("fuzzfile")
+        .unwrap()
+        .into_file();
+
+    // A backend that can execute a virtio-blk request
+    let mut backend = StdIoBackend::new(memfile, fuzz_input.features).unwrap();
+    if let Some(id) = fuzz_input.device_id {
+        backend = backend.with_device_id(id);
+    }
+
+    // Build a descriptor chain, parse and execute a request
+    if let Ok(mut chain) = vq.build_desc_chain(&descriptors) {
+        if let Ok(req) = Request::parse(&mut chain) {
+            // Ensure the compiler does not optimize the request away
+            let _ = black_box(backend.process_request(&m, &req));
+        };
+    }
+});


### PR DESCRIPTION
### Summary of the PR

Add a new `cargo-fuzz` target to test `virtio-blk` request parsing. Add as well a simple test.

This new target mimics the existing `virtio-vsock` one in a much simpler way, as the `virtio-blk` interface is smaller.

### Requirements

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
