### PR TITLE
Update to vm-memory 0.13.1

### DIFF
--- a/crates/devices/virtio-blk/Cargo.toml
+++ b/crates/devices/virtio-blk/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 backend-stdio = []
 
 [dependencies]
-vm-memory = "0.12.0"
+vm-memory = "0.13.1"
 vmm-sys-util = "0.11.0"
 log = "0.4.17"
 virtio-queue = { path = "../../virtio-queue" }
@@ -21,5 +21,5 @@ virtio-device = { path = "../../virtio-device" }
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.1" }
 
 [dev-dependencies]
-vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
 virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }

--- a/crates/devices/virtio-console/Cargo.toml
+++ b/crates/devices/virtio-console/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.1" }
 virtio-queue = { path = "../../virtio-queue", version = "0.9.0" }
-vm-memory = "0.12.0"
+vm-memory = "0.13.1"
 
 [dev-dependencies]
 virtio-queue = { path = "../../virtio-queue", version = "0.9.0", features = ["test-utils"] }
-vm-memory = { version = "0.12.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap"] }

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 # The `path` part gets stripped when publishing the crate.
 virtio-queue = { path = "../../virtio-queue", version = "0.9.0" }
 virtio-bindings = { path = "../../virtio-bindings", version = "0.2.1" }
-vm-memory = "0.12.0"
+vm-memory = "0.13.1"
 
 [dev-dependencies]
 virtio-queue = { path = "../../virtio-queue", version = "0.9.0", features = ["test-utils"] }
-vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-device/Cargo.toml
+++ b/crates/virtio-device/Cargo.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0 OR MIT"
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.12.0"
+vm-memory = "0.13.1"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
 virtio-queue = { path = "../virtio-queue", version = "0.9.0"}
 
 [dev-dependencies]
-vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/virtio-queue-ser/Cargo.toml
+++ b/crates/virtio-queue-ser/Cargo.toml
@@ -18,7 +18,7 @@ versionize_derive = "0.1.3"
 # and virtio-queue-ser releases. This is to prevent accidental changes
 # to the serializer output in a patch release of virtio-queue. 
 virtio-queue = { path = "../../crates/virtio-queue", version = "=0.9.0" }
-vm-memory = "0.12.0"
+vm-memory = "0.13.1"
 
 [dev-dependencies]
 virtio-queue = { path = "../../crates/virtio-queue", version = "=0.9.0", features = ["test-utils"] }

--- a/crates/virtio-queue/Cargo.toml
+++ b/crates/virtio-queue/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2021"
 test-utils = []
 
 [dependencies]
-vm-memory = "0.12.0"
+vm-memory = "0.13.1"
 vmm-sys-util = "0.11.0"
 log = "0.4.17"
 virtio-bindings = { path="../virtio-bindings", version = "0.2.1" }
 
 [dev-dependencies]
 criterion = "0.3.0"
-vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
 memoffset = "0.7.1"
 
 [[bench]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.63"
 virtio-queue = { path = "../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../crates/virtio-queue-ser" }
-vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
 
 [[bin]]

--- a/fuzz/common/Cargo.toml
+++ b/fuzz/common/Cargo.toml
@@ -12,4 +12,4 @@ virtio-bindings = { path = "../../crates/virtio-bindings" }
 virtio-queue = { path = "../../crates/virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../../crates/devices/virtio-vsock" }
 virtio-queue-ser = { path = "../../crates/virtio-queue-ser" }
-vm-memory = { version = "0.12.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
Mostly this introduces the traits WriteVolatile and ReadVolatile. Since these can deal more efficiently deal with the volatile semantics, some old methods got deprecated.

Mostly that means replacing Read/Write with {Read,Write}Volatile.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
