### PR TITLE
fix "useless-vec" clippy warning

### DIFF
--- a/crates/devices/virtio-blk/src/request.rs
+++ b/crates/devices/virtio-blk/src/request.rs
@@ -295,7 +295,7 @@ mod tests {
         let mem: GuestMemoryMmap =
             GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000_0000)]).unwrap();
         // The `build_desc_chain` function will populate the `NEXT` related flags and field.
-        let v = vec![
+        let v = [
             // A device-writable request header descriptor.
             Descriptor::new(0x10_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
             Descriptor::new(0x20_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
@@ -318,7 +318,7 @@ mod tests {
             Error::UnexpectedWriteOnlyDescriptor
         );
 
-        let v = vec![
+        let v = [
             Descriptor::new(0x10_0000, 0x100, 0, 0),
             Descriptor::new(0x20_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
             // A device-readable request status descriptor.
@@ -332,7 +332,7 @@ mod tests {
             Error::UnexpectedReadOnlyDescriptor
         );
 
-        let v = vec![
+        let v = [
             Descriptor::new(0x10_0000, 0x100, 0, 0),
             Descriptor::new(0x20_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
             // Status descriptor with len = 0.
@@ -344,7 +344,7 @@ mod tests {
             Error::DescriptorLengthTooSmall
         );
 
-        let v = vec![
+        let v = [
             Descriptor::new(0x10_0000, 0x100, 0, 0),
             Descriptor::new(0x20_0000, 0x100, 0, 0),
             Descriptor::new(0x30_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
@@ -376,7 +376,7 @@ mod tests {
         );
 
         // Invalid status address.
-        let v = vec![
+        let v = [
             Descriptor::new(0x10_0000, 0x100, 0, 0),
             Descriptor::new(0x20_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
             Descriptor::new(0x30_0000, 0x200, VRING_DESC_F_WRITE as u16, 0),
@@ -401,7 +401,7 @@ mod tests {
         );
 
         // Valid descriptor chain for OUT.
-        let v = vec![
+        let v = [
             Descriptor::new(0x10_0000, 0x100, 0, 0),
             Descriptor::new(0x20_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
             Descriptor::new(0x30_0000, 0x200, VRING_DESC_F_WRITE as u16, 0),
@@ -446,7 +446,7 @@ mod tests {
         assert_eq!(request.request_type(), RequestType::Unsupported(2));
 
         // Valid descriptor chain for FLUSH.
-        let v = vec![
+        let v = [
             Descriptor::new(0x10_0000, 0x100, 0, 0),
             Descriptor::new(0x40_0000, 0x100, VRING_DESC_F_WRITE as u16, 0),
         ];

--- a/crates/devices/virtio-console/src/console.rs
+++ b/crates/devices/virtio-console/src/console.rs
@@ -351,7 +351,7 @@ mod tests {
             GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x0001_0000)]).unwrap();
 
         // One descriptor is write only
-        let v = vec![
+        let v = [
             Descriptor::new(0x1000, INPUT_SIZE, 0, 0),
             Descriptor::new(0x2000, INPUT_SIZE, VRING_DESC_F_WRITE as u16, 0),
         ];
@@ -365,7 +365,7 @@ mod tests {
         );
 
         // Descriptor is outside of the memory bounds
-        let v = vec![
+        let v = [
             Descriptor::new(0x0001_0000, INPUT_SIZE, 0, 0),
             Descriptor::new(0x0002_0000, INPUT_SIZE, 0, 0),
         ];
@@ -378,7 +378,7 @@ mod tests {
         );
 
         // Test normal functionality.
-        let v = vec![
+        let v = [
             Descriptor::new(0x3000, INPUT_SIZE, 0, 0),
             Descriptor::new(0x4000, INPUT_SIZE, 0, 0),
         ];
@@ -418,7 +418,7 @@ mod tests {
             GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x0001_0000)]).unwrap();
 
         // One descriptor is read only
-        let v = vec![
+        let v = [
             Descriptor::new(0x1000, 0x10, VRING_DESC_F_WRITE as u16, 0),
             Descriptor::new(0x2000, INPUT_SIZE, 0, 0),
         ];
@@ -432,7 +432,7 @@ mod tests {
         );
 
         // Descriptor is out of memory bounds
-        let v = vec![
+        let v = [
             Descriptor::new(0x0001_0000, INPUT_SIZE, VRING_DESC_F_WRITE as u16, 0),
             Descriptor::new(0x0002_0000, INPUT_SIZE, VRING_DESC_F_WRITE as u16, 0),
         ];
@@ -454,7 +454,7 @@ mod tests {
         console
             .enqueue_data(&mut vec![INPUT_VALUE * 2; INPUT_SIZE as usize])
             .unwrap();
-        let v = vec![
+        let v = [
             Descriptor::new(0x3000, INPUT_SIZE, VRING_DESC_F_WRITE as u16, 0),
             Descriptor::new(0x4000, INPUT_SIZE, VRING_DESC_F_WRITE as u16, 0),
         ];
@@ -477,7 +477,7 @@ mod tests {
         console
             .enqueue_data(&mut vec![INPUT_VALUE; 2 * INPUT_SIZE as usize])
             .unwrap();
-        let v = vec![Descriptor::new(
+        let v = [Descriptor::new(
             0x5000,
             INPUT_SIZE,
             VRING_DESC_F_WRITE as u16,
@@ -497,7 +497,7 @@ mod tests {
 
         assert!(!console.is_input_buffer_empty());
 
-        let v = vec![Descriptor::new(
+        let v = [Descriptor::new(
             0x6000,
             INPUT_SIZE,
             VRING_DESC_F_WRITE as u16,
@@ -516,7 +516,7 @@ mod tests {
         assert!(console.is_input_buffer_empty());
 
         // Input buffer is empty.
-        let v = vec![Descriptor::new(
+        let v = [Descriptor::new(
             0x7000,
             INPUT_SIZE,
             VRING_DESC_F_WRITE as u16,


### PR DESCRIPTION
This warning is new in latest Rust and breaks when updating the CI environment [1].

[1] https://github.com/rust-vmm/vm-virtio/pull/258

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
