### PR TITLE
bindings: add `virtio_ids` module

### DIFF
--- a/crates/virtio-bindings/CHANGELOG.md
+++ b/crates/virtio-bindings/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+## Added
+
+- Exposed virtio_ids.h bindings as a public module.
+
 # v0.2.2
 
 ## Added

--- a/crates/virtio-bindings/src/lib.rs
+++ b/crates/virtio-bindings/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod virtio_blk;
 pub mod virtio_config;
 pub mod virtio_gpu;
+pub mod virtio_ids;
 pub mod virtio_mmio;
 pub mod virtio_net;
 pub mod virtio_ring;


### PR DESCRIPTION
### Summary of the PR

Bindings for the virtio IDs were added in commit 1f2dd436, but they were never exposed to users of the crate. Do so by adding a public module.

Fixes: 1f2dd436 ("bindings: add bindings for virtio_ids.h")

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
