### PR TITLE
virtio-vsock: new release 0.4.0

### DIFF
--- a/crates/devices/virtio-vsock/CHANGELOG.md
+++ b/crates/devices/virtio-vsock/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Upcoming
 
-# v0.3.2
+# v0.4.0
+
+Mostly identical to v0.3.2, which was incorrectly published as minor release.
+
+## Changes
+
+- Update virtio-queue from 0.9.1 to 0.10.0 (same minor/major problems)
+
+# v0.3.2 - yanked
+
+This version got yanked. It should have been a major release. The vm-memory
+dependency - which received a major bump - is part of the public interface.
 
 ## Changes
 

--- a/crates/devices/virtio-vsock/Cargo.toml
+++ b/crates/devices/virtio-vsock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-vsock"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "virtio vsock device implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
We have the same vm-memory dependency as virtio-queue. So the previous release should have been a major.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- `na` All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- `na` Any newly added `unsafe` code is properly documented.
