### PR TITLE
Update vmm-sys-util to 0.12.0

### DIFF
--- a/virtio-blk/Cargo.toml
+++ b/virtio-blk/Cargo.toml
@@ -14,7 +14,7 @@ backend-stdio = []
 
 [dependencies]
 vm-memory = "0.13.1"
-vmm-sys-util = "0.11.0"
+vmm-sys-util = "0.12.1"
 log = "0.4.17"
 virtio-queue = { path = "../virtio-queue" }
 virtio-device = { path = "../virtio-device" }

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.27", features = ["derive"] }
-versionize = "0.1.6"
+versionize = "0.2.0"
 versionize_derive = "0.1.3"
 # The `path` part gets stripped when publishing the crate.
 # We use strict version dependencies (`=x.y.z`) as we maintain a

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -14,7 +14,7 @@ test-utils = []
 
 [dependencies]
 vm-memory = "0.13.1"
-vmm-sys-util = "0.11.0"
+vmm-sys-util = "0.12.1"
 log = "0.4.17"
 virtio-bindings = { path="../virtio-bindings", version = "0.2.2" }
 


### PR DESCRIPTION
Hey everyone, I am propagating some dependency updates across the rust-vmm ecosystem. This one brings a fix for a security vulnerability behind feature-gated code not used by vm-virtio (the `with-serde` feature), see GHSA-875g-mfp6-g7f9, but its probably nice-to-have to prevent `cargo audit` from blocking CIs :) 

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
