### PR TITLE
Prepare virtio-queue v0.11.0 and virtio-queue-ser v0.8.0 releases

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.98,
+  "coverage_score": 86.05,
   "exclude_path": "virtio-bindings|virtio-queue/src/mock\\.rs",
   "crate_features": "virtio-blk/backend-stdio"
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ memfd = "0.6.3"
 virtio-queue = { path = "../virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../virtio-vsock" }
 virtio-queue-ser = { path = "../virtio-queue-ser" }
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
 virtio-blk = { path = "../virtio-blk", features = ["backend-stdio"] }
 

--- a/fuzz/common/Cargo.toml
+++ b/fuzz/common/Cargo.toml
@@ -13,4 +13,4 @@ virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../../virtio-vsock" }
 virtio-queue-ser = { path = "../../virtio-queue-ser" }
 virtio-blk = { path = "../../virtio-blk" }
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-blk/Cargo.toml
+++ b/virtio-blk/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 backend-stdio = []
 
 [dependencies]
-vm-memory = "0.13.1"
+vm-memory = "0.14.0"
 vmm-sys-util = "0.12.1"
 log = "0.4.17"
 virtio-queue = { path = "../virtio-queue" }
@@ -21,5 +21,5 @@ virtio-device = { path = "../virtio-device" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
 
 [dev-dependencies]
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
 virtio-queue = { path = "../virtio-queue", features = ["test-utils"] }

--- a/virtio-console/Cargo.toml
+++ b/virtio-console/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
 virtio-queue = { path = "../virtio-queue", version = "0.10.0" }
-vm-memory = "0.13.1"
+vm-memory = "0.14.0"
 
 [dev-dependencies]
 virtio-queue = { path = "../virtio-queue", version = "0.10.0", features = ["test-utils"] }
-vm-memory = { version = "0.13.1", features = ["backend-mmap"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap"] }

--- a/virtio-console/Cargo.toml
+++ b/virtio-console/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2021"
 
 [dependencies]
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
-virtio-queue = { path = "../virtio-queue", version = "0.10.0" }
+virtio-queue = { path = "../virtio-queue", version = "0.11.0" }
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.10.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "0.11.0", features = ["test-utils"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap"] }

--- a/virtio-device/Cargo.toml
+++ b/virtio-device/Cargo.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0 OR MIT"
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.13.1"
+vm-memory = "0.14.0"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
 virtio-queue = { path = "../virtio-queue", version = "0.10.0"}
 
 [dev-dependencies]
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-device/Cargo.toml
+++ b/virtio-device/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 vm-memory = "0.14.0"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
-virtio-queue = { path = "../virtio-queue", version = "0.10.0"}
+virtio-queue = { path = "../virtio-queue", version = "0.11.0"}
 
 [dev-dependencies]
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-queue-ser/CHANGELOG.md
+++ b/virtio-queue-ser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Upcoming release
 
+# v0.8.0
+
+## Changed
+
+- Updated vm-memory from 0.13.1 to 0.14.0.
+- Updated virtio-queue from 0.10.0 to 0.11.0.
+- Updated versionize from 0.1.6 to 0.2.0.
+
 # v0.7.0
 
 - Updated virtio-queue from 0.9.1 to 0.10.0.

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -18,8 +18,8 @@ versionize_derive = "0.1.3"
 # 1:1-relationship between virtio-queue and virtio-queue-ser releases. This is
 # to prevent accidental changes to the serializer output in a patch release of
 # virtio-queue.
-virtio-queue = { path = "../virtio-queue", version = "=0.10.0" }
+virtio-queue = { path = "../virtio-queue", version = "=0.11.0" }
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "=0.10.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "=0.11.0", features = ["test-utils"] }

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue-ser"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "Serialization for virtio queue state"
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -19,7 +19,7 @@ versionize_derive = "0.1.3"
 # to prevent accidental changes to the serializer output in a patch release of
 # virtio-queue.
 virtio-queue = { path = "../virtio-queue", version = "=0.10.0" }
-vm-memory = "0.13.1"
+vm-memory = "0.14.0"
 
 [dev-dependencies]
 virtio-queue = { path = "../virtio-queue", version = "=0.10.0", features = ["test-utils"] }

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
 
+# v0.11.0
+
+## Changed
+- Updated vm-memory from 0.13.1 to 0.14.0
+- Updated vmm-sys-util from 0.11.0 to 0.12.1
+
 # v0.10.0
 
 Identical to v0.9.1, which was incorrectly published as minor release.

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2021"
 test-utils = []
 
 [dependencies]
-vm-memory = "0.13.1"
+vm-memory = "0.14.0"
 vmm-sys-util = "0.12.1"
 log = "0.4.17"
 virtio-bindings = { path="../virtio-bindings", version = "0.2.2" }
 
 [dev-dependencies]
 criterion = "0.5.1"
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
 memoffset = "0.9.0"
 
 [[bench]]

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["The Chromium OS Authors"]
 description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 # The `path` part gets stripped when publishing the crate.
 virtio-queue = { path = "../virtio-queue", version = "0.10.0" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
-vm-memory = "0.13.1"
+vm-memory = "0.14.0"
 
 [dev-dependencies]
 virtio-queue = { path = "../virtio-queue", version = "0.10.0", features = ["test-utils"] }
-vm-memory = { version = "0.13.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 
 [dependencies]
 # The `path` part gets stripped when publishing the crate.
-virtio-queue = { path = "../virtio-queue", version = "0.10.0" }
+virtio-queue = { path = "../virtio-queue", version = "0.11.0" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.10.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "0.11.0", features = ["test-utils"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
### Summary of the PR

This release contains update of dependencies used in several APIs (e.g. `vm-memory`).
`vm-memory `was just updated for dependency with `vmm-sys-util` where a security issue was fixed.

This release is blocking for https://github.com/rust-vmm/vhost/pull/220

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
