### PR TITLE
virtio-vsock: release v0.5.0

### DIFF
--- a/virtio-vsock/CHANGELOG.md
+++ b/virtio-vsock/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Upcoming
 
+# v0.5.0
+
+## Changes
+
+- Update vm-memory from 0.13.1 to 0.14.0.
+- Update virtio-queue from 0.10.0 to 0.11.0.
+
 # v0.4.0
 
 Mostly identical to v0.3.2, which was incorrectly published as minor release.

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-vsock"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "virtio vsock device implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
### Summary of the PR

This release contains update of dependencies used in several APIs (e.g. vm-memory).
This is needed for `vhost-device`, where CI is failing, if we update `vm-memory` and other crates to the latest version: https://github.com/rust-vmm/vhost-device/pull/596

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
