### PR TITLE
Prepare the release of virtio-queue v0.12.0 and virtio-queue-ser v0.9.0

### DIFF
--- a/virtio-console/Cargo.toml
+++ b/virtio-console/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2021"
 
 [dependencies]
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
-virtio-queue = { path = "../virtio-queue", version = "0.11.0" }
+virtio-queue = { path = "../virtio-queue", version = "0.12.0" }
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.11.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "0.12.0", features = ["test-utils"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap"] }

--- a/virtio-device/Cargo.toml
+++ b/virtio-device/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 vm-memory = "0.14.0"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
-virtio-queue = { path = "../virtio-queue", version = "0.11.0"}
+virtio-queue = { path = "../virtio-queue", version = "0.12.0"}
 
 [dev-dependencies]
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-queue-ser/CHANGELOG.md
+++ b/virtio-queue-ser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming release
 
+# v0.9.0
+
+- Updated virtio-queue from 0.11.0 to 0.12.0.
+
 # v0.8.0
 
 ## Changed

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue-ser"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "Serialization for virtio queue state"
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -18,8 +18,8 @@ versionize_derive = "0.1.3"
 # 1:1-relationship between virtio-queue and virtio-queue-ser releases. This is
 # to prevent accidental changes to the serializer output in a patch release of
 # virtio-queue.
-virtio-queue = { path = "../virtio-queue", version = "=0.11.0" }
+virtio-queue = { path = "../virtio-queue", version = "=0.12.0" }
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "=0.11.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "=0.12.0", features = ["test-utils"] }

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming
 
+# v0.12.0
+
+## Added
+- `Reader`/`Writer` classes to iterate over descriptors
+
 # v0.11.0
 
 ## Changed

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["The Chromium OS Authors"]
 description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 
 [dependencies]
 # The `path` part gets stripped when publishing the crate.
-virtio-queue = { path = "../virtio-queue", version = "0.11.0" }
+virtio-queue = { path = "../virtio-queue", version = "0.12.0" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.11.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "0.12.0", features = ["test-utils"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
### Summary of the PR

This release contains the new `Reader`/`Writer` classes to iterate over descriptors.
This is useful for vhost devices (see https://github.com/rust-vmm/vhost-device/pull/580).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
