### PR TITLE
virtio-vsock: release v0.6.0

### DIFF
--- a/virtio-vsock/CHANGELOG.md
+++ b/virtio-vsock/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
 
+# v0.6.0
+
+## Changes
+
+- Update virtio-queue from 0.11.0 to 0.12.0.
+
 # v0.5.0
 
 ## Changes

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-vsock"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["rust-vmm community", "rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 description = "virtio vsock device implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
This release contains update of virtio-queue dependency.