### PR TITLE
use virtio-queue from crates.io to prevent dupes in Cargo.lock

### DIFF
--- a/virtio-blk/Cargo.toml
+++ b/virtio-blk/Cargo.toml
@@ -16,10 +16,10 @@ backend-stdio = []
 vm-memory = "0.14.0"
 vmm-sys-util = "0.12.1"
 log = "0.4.17"
-virtio-queue = { path = "../virtio-queue" }
+virtio-queue = "0.12.0"
 virtio-device = { path = "../virtio-device" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
 
 [dev-dependencies]
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }
-virtio-queue = { path = "../virtio-queue", features = ["test-utils"] }
+virtio-queue = { version = "0.12.0", features = ["test-utils"] }

--- a/virtio-console/Cargo.toml
+++ b/virtio-console/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2021"
 
 [dependencies]
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
-virtio-queue = { path = "../virtio-queue", version = "0.12.0" }
+virtio-queue = "0.12.0"
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.12.0", features = ["test-utils"] }
+virtio-queue = { version = "0.12.0", features = ["test-utils"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap"] }

--- a/virtio-device/Cargo.toml
+++ b/virtio-device/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 vm-memory = "0.14.0"
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
-virtio-queue = { path = "../virtio-queue", version = "0.12.0"}
+virtio-queue = "0.12.0"
 
 [dev-dependencies]
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -10,11 +10,10 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2021"
 
 [dependencies]
-# The `path` part gets stripped when publishing the crate.
-virtio-queue = { path = "../virtio-queue", version = "0.12.0" }
+virtio-queue = "0.12.0"
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.2" }
 vm-memory = "0.14.0"
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.12.0", features = ["test-utils"] }
+virtio-queue = { version = "0.12.0", features = ["test-utils"] }
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
### Summary of the PR

Use the published virtio-queue to prevent unwanted duplicates in Cargo.lock when consuming both am unpublished device and a released virtio-queue.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
