### PR TITLE
build: Update vm-memory from 0.15.0 to 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ members = [
 [profile.bench]
 lto = true
 codegen-units = 1
+
+[workspace.dependencies]
+vm-memory = "0.15.0"
+vmm-sys-util = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
-vm-memory = "0.15.0"
+vm-memory = "0.16.0"
 vmm-sys-util = "0.12.1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ memfd = "0.6.3"
 virtio-queue = { path = "../virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../virtio-vsock" }
 virtio-queue-ser = { path = "../virtio-queue-ser" }
-vm-memory = { version = "0.15.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.16.0", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
 virtio-blk = { path = "../virtio-blk", features = ["backend-stdio"] }
 

--- a/fuzz/common/Cargo.toml
+++ b/fuzz/common/Cargo.toml
@@ -13,4 +13,4 @@ virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../../virtio-vsock" }
 virtio-queue-ser = { path = "../../virtio-queue-ser" }
 virtio-blk = { path = "../../virtio-blk" }
-vm-memory = { version = "0.15.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.16.0", features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-blk/Cargo.toml
+++ b/virtio-blk/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2021"
 backend-stdio = []
 
 [dependencies]
-vm-memory = "0.15.0"
-vmm-sys-util = "0.12.1"
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 log = "0.4.17"
 virtio-queue = { path = "../virtio-queue" }
 virtio-device = { path = "../virtio-device" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.3" }
 
 [dev-dependencies]
-vm-memory = { version = "0.15.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 virtio-queue = { path = "../virtio-queue", features = ["test-utils"] }

--- a/virtio-console/Cargo.toml
+++ b/virtio-console/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.3" }
 virtio-queue = { path = "../virtio-queue", version = "0.13.0" }
-vm-memory = "0.15.0"
+vm-memory = { workspace = true }
 
 [dev-dependencies]
 virtio-queue = { path = "../virtio-queue", version = "0.13.0", features = ["test-utils"] }
-vm-memory = { version = "0.15.0", features = ["backend-mmap"] }
+vm-memory = { workspace = true, features = ["backend-mmap"] }

--- a/virtio-device/Cargo.toml
+++ b/virtio-device/Cargo.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0 OR MIT"
 edition = "2021"
 
 [dependencies]
-vm-memory = "0.15.0"
+vm-memory = { workspace = true }
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
 virtio-queue = { path = "../virtio-queue", version = "0.13.0"}
 
 [dev-dependencies]
-vm-memory = { version = "0.15.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -19,7 +19,7 @@ versionize_derive = "0.1.3"
 # to prevent accidental changes to the serializer output in a patch release of
 # virtio-queue.
 virtio-queue = { path = "../virtio-queue", version = "=0.13.0" }
-vm-memory = "0.15.0"
+vm-memory = { workspace = true }
 
 [dev-dependencies]
 virtio-queue = { path = "../virtio-queue", version = "=0.13.0", features = ["test-utils"] }

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2021"
 test-utils = []
 
 [dependencies]
-vm-memory = "0.15.0"
-vmm-sys-util = "0.12.1"
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 log = "0.4.17"
 virtio-bindings = { path="../virtio-bindings", version = "0.2.3" }
 
 [dev-dependencies]
 criterion = "0.5.1"
-vm-memory = { version = "0.15.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 memoffset = "0.9.0"
 
 [[bench]]

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 # The `path` part gets stripped when publishing the crate.
 virtio-queue = { path = "../virtio-queue", version = "0.13.0" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.3" }
-vm-memory = "0.15.0"
+vm-memory = { workspace = true }
 
 [dev-dependencies]
 virtio-queue = { path = "../virtio-queue", version = "0.13.0", features = ["test-utils"] }
-vm-memory = { version = "0.15.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
### Summary of the PR

- build: Centralize rust-vmm crates to workspace
- build: Update vm-memory from 0.15.0 to 0.16.0

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
