### PR TITLE
Add license files in published crate part of this workspace

### DIFF
--- a/virtio-bindings/CHANGELOG.md
+++ b/virtio-bindings/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming Release
 
+## Fixed
+
+- Add license files.
+
 # v0.2.4
 
 ## Changed

--- a/virtio-bindings/LICENSE-APACHE
+++ b/virtio-bindings/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/virtio-bindings/LICENSE-BSD-3-Clause
+++ b/virtio-bindings/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../LICENSE-BSD-3-Clause

--- a/virtio-queue-ser/CHANGELOG.md
+++ b/virtio-queue-ser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming release
 
+## Fixed
+
+- Add license files.
+
 # v0.11.0
 
 ## Changed

--- a/virtio-queue-ser/LICENSE-APACHE
+++ b/virtio-queue-ser/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/virtio-queue-ser/LICENSE-BSD-3-Clause
+++ b/virtio-queue-ser/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../LICENSE-BSD-3-Clause

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+## Fixed
+
+- Add license files.
+
 # v0.14.0
 
 ## Changed

--- a/virtio-queue/LICENSE-APACHE
+++ b/virtio-queue/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/virtio-queue/LICENSE-BSD-3-Clause
+++ b/virtio-queue/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../LICENSE-BSD-3-Clause

--- a/virtio-vsock/CHANGELOG.md
+++ b/virtio-vsock/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+## Fixed
+
+- Add license files.
+
 # v0.8.0
 
 ## Changed

--- a/virtio-vsock/LICENSE-APACHE
+++ b/virtio-vsock/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/virtio-vsock/LICENSE-BSD-3-Clause
+++ b/virtio-vsock/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../LICENSE-BSD-3-Clause


### PR DESCRIPTION
### Summary of the PR

Add a symbolic link to license files in each crate we publish to avoid problems like this:

    $ rust2rpm -t fedora -a -s virtio-vsock 0.6.0
    ERROR: No license files were detected. In almost all cases, this is an issue
           with the upstream project that should be reported.

In the other unpublished crates we have different licenses that we should resolve before publishing and link the right license files.

Fixes: #298

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
