### PR TITLE
New round of clippy warning fixups 

### DIFF
--- a/virtio-blk/src/request.rs
+++ b/virtio-blk/src/request.rs
@@ -275,6 +275,7 @@ mod tests {
     }
 
     impl Request {
+        /// Manually create mock `Request` instances.
         pub fn new(
             request_type: RequestType,
             data: Vec<(GuestAddress, u32)>,

--- a/virtio-queue/src/descriptor_utils.rs
+++ b/virtio-queue/src/descriptor_utils.rs
@@ -232,7 +232,7 @@ impl<'a, B: BitmapSlice> Reader<'a, B> {
     }
 }
 
-impl<'a, B: BitmapSlice> io::Read for Reader<'a, B> {
+impl<B: BitmapSlice> io::Read for Reader<'_, B> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.buffer.consume(buf.len(), |bufs| {
             let mut rem = buf;
@@ -333,7 +333,7 @@ impl<'a, B: BitmapSlice> Writer<'a, B> {
     }
 }
 
-impl<'a, B: BitmapSlice> io::Write for Writer<'a, B> {
+impl<B: BitmapSlice> io::Write for Writer<'_, B> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.buffer.consume(buf.len(), |bufs| {
             let mut rem = buf;

--- a/virtio-queue/src/queue.rs
+++ b/virtio-queue/src/queue.rs
@@ -730,7 +730,7 @@ where
     }
 }
 
-impl<'b, M> Iterator for AvailIter<'b, M>
+impl<M> Iterator for AvailIter<'_, M>
 where
     M: Clone + Deref,
     M::Target: GuestMemory,

--- a/virtio-vsock/src/packet.rs
+++ b/virtio-vsock/src/packet.rs
@@ -1381,14 +1381,6 @@ mod tests {
     fn test_set_header_field_with_invalid_offset() {
         const INVALID_OFFSET: usize = 50;
 
-        impl<'a, B: BitmapSlice> VsockPacket<'a, B> {
-            /// Set the `src_cid` of the header, but use an invalid offset for that.
-            pub fn set_src_cid_invalid(&mut self, cid: u64) -> &mut Self {
-                set_header_field!(self, src_cid, INVALID_OFFSET, cid);
-                self
-            }
-        }
-
         let mem: GuestMemoryMmap =
             GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x30_0000)]).unwrap();
         // The `build_desc_chain` function will populate the `NEXT` related flags and field.
@@ -1401,6 +1393,7 @@ mod tests {
 
         let mut packet =
             VsockPacket::from_rx_virtq_chain(&mem, &mut chain, MAX_PKT_BUF_SIZE).unwrap();
-        packet.set_src_cid_invalid(SRC_CID);
+        // Set the `src_cid` of the header, but use an invalid offset for that.
+        set_header_field!(packet, src_cid, INVALID_OFFSET, SRC_CID);
     }
 }


### PR DESCRIPTION
Fixes for new minor lint warnings that cause error in CI.

Signed-off-by: Manos Pitsidianakis <manos.pitsidianakis@linaro.org>