### PR TITLE
virtio-bindings: Prepare v0.2.5 release

### DIFF
--- a/virtio-bindings/CHANGELOG.md
+++ b/virtio-bindings/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Upcoming Release
 
+# v0.2.5
+
 ## Changed
 
 - Regenerate bindings with Linux 6.12.

--- a/virtio-bindings/Cargo.toml
+++ b/virtio-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-bindings"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 description = "Rust FFI bindings to virtio generated using bindgen."
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/virtio-blk/Cargo.toml
+++ b/virtio-blk/Cargo.toml
@@ -18,7 +18,7 @@ vmm-sys-util = { workspace = true }
 log = "0.4.17"
 virtio-queue = { path = "../virtio-queue" }
 virtio-device = { path = "../virtio-device" }
-virtio-bindings = { path = "../virtio-bindings", version = "0.2.4" }
+virtio-bindings = { path = "../virtio-bindings", version = "0.2.5" }
 
 [dev-dependencies]
 vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-console/Cargo.toml
+++ b/virtio-console/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 
 [dependencies]
-virtio-bindings = { path = "../virtio-bindings", version = "0.2.4" }
+virtio-bindings = { path = "../virtio-bindings", version = "0.2.5" }
 virtio-queue = { path = "../virtio-queue", version = "0.14.0" }
 vm-memory = { workspace = true }
 

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add license files.
 
+## Changed
+
+- Updated virtio-bindings from 0.2.4 to 0.2.5.
+
 # v0.14.0
 
 ## Changed

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -16,7 +16,7 @@ test-utils = []
 vm-memory = { workspace = true }
 vmm-sys-util = { workspace = true }
 log = "0.4.17"
-virtio-bindings = { path="../virtio-bindings", version = "0.2.4" }
+virtio-bindings = { path="../virtio-bindings", version = "0.2.5" }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/virtio-vsock/CHANGELOG.md
+++ b/virtio-vsock/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add license files.
 
+## Changed
+
+- Updated virtio-bindings from 0.2.4 to 0.2.5.
+
 # v0.8.0
 
 ## Changed

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 # The `path` part gets stripped when publishing the crate.
 virtio-queue = { path = "../virtio-queue", version = "0.14.0" }
-virtio-bindings = { path = "../virtio-bindings", version = "0.2.4" }
+virtio-bindings = { path = "../virtio-bindings", version = "0.2.5" }
 vm-memory = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Changed

- Regenerate bindings with Linux 6.12.
- Introduced bindgen build dependency and its clang development package dependency. See bindgen fix below for why this was necessary.

Fixed

- Add license files.
- Use bindgen library from build.rs to fix i686 builds due to x86_64-specific alignment checks.

Closes: #328