### PR TITLE
virtio-queue: fix clippy warnings on Rust 1.85

### DIFF
--- a/virtio-queue/src/queue.rs
+++ b/virtio-queue/src/queue.rs
@@ -312,7 +312,7 @@ impl QueueT for Queue {
             false
         } else if desc_table
             .checked_add(desc_table_size)
-            .map_or(true, |v| !mem.address_in_range(v))
+            .is_none_or(|v| !mem.address_in_range(v))
         {
             error!(
                 "virtio queue descriptor table goes out of bounds: start:0x{:08x} size:0x{:08x}",
@@ -322,7 +322,7 @@ impl QueueT for Queue {
             false
         } else if avail_ring
             .checked_add(avail_ring_size)
-            .map_or(true, |v| !mem.address_in_range(v))
+            .is_none_or(|v| !mem.address_in_range(v))
         {
             error!(
                 "virtio queue available ring goes out of bounds: start:0x{:08x} size:0x{:08x}",
@@ -332,7 +332,7 @@ impl QueueT for Queue {
             false
         } else if used_ring
             .checked_add(used_ring_size)
-            .map_or(true, |v| !mem.address_in_range(v))
+            .is_none_or(|v| !mem.address_in_range(v))
         {
             error!(
                 "virtio queue used ring goes out of bounds: start:0x{:08x} size:0x{:08x}",


### PR DESCRIPTION
### Summary of the PR

Our CI is being upgraded to Rust 1.85 and this will produce new warnings from clippy like this one:
```
  error: this `map_or` can be simplified
      --> virtio-queue/src/queue.rs:313:19
       |
   313 |           } else if desc_table
       |  ___________________^
   314 | |             .checked_add(desc_table_size)
   315 | |             .map_or(true, |v| !mem.address_in_range(v))
       | |_______________________________________________________^
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
       = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
       = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_or)]`
   help: use is_none_or instead
       |
   313 ~         } else if desc_table
   314 +             .checked_add(desc_table_size).is_none_or(|v| !mem.address_in_range(v))
```
Apply the advice using `cargo clippy --fix`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
