### PR TITLE
virtio-queue: Fix warning from nightly compiler

### DIFF
--- a/virtio-queue/src/lib.rs
+++ b/virtio-queue/src/lib.rs
@@ -154,7 +154,7 @@ pub trait QueueT: for<'a> QueueGuard<'a> {
     ///
     /// Logically this method will acquire the underlying lock protecting the `Queue` Object.
     /// The lock will be released when the returned object gets dropped.
-    fn lock(&mut self) -> <Self as QueueGuard>::G;
+    fn lock(&mut self) -> <Self as QueueGuard<'_>>::G;
 
     /// Get the maximum size of the virtio queue.
     fn max_size(&self) -> u16;

--- a/virtio-queue/src/mock.rs
+++ b/virtio-queue/src/mock.rs
@@ -330,12 +330,12 @@ impl<'a, M: GuestMemory> MockSplitQueue<'a, M> {
     }
 
     /// Available ring accessor.
-    pub fn avail(&self) -> &AvailRing<M> {
+    pub fn avail(&self) -> &AvailRing<'_, M> {
         &self.avail
     }
 
     /// Used ring accessor.
-    pub fn used(&self) -> &UsedRing<M> {
+    pub fn used(&self) -> &UsedRing<'_, M> {
         &self.used
     }
 

--- a/virtio-queue/src/queue.rs
+++ b/virtio-queue/src/queue.rs
@@ -357,7 +357,7 @@ impl QueueT for Queue {
         self.event_idx_enabled = false;
     }
 
-    fn lock(&mut self) -> <Self as QueueGuard>::G {
+    fn lock(&mut self) -> <Self as QueueGuard<'_>>::G {
         self
     }
 

--- a/virtio-queue/src/queue_sync.rs
+++ b/virtio-queue/src/queue_sync.rs
@@ -43,7 +43,7 @@ pub struct QueueSync {
 }
 
 impl QueueSync {
-    fn lock_state(&self) -> MutexGuard<Queue> {
+    fn lock_state(&self) -> MutexGuard<'_, Queue> {
         // Do not expect poisoned lock.
         self.state.lock().unwrap()
     }
@@ -68,7 +68,7 @@ impl QueueT for QueueSync {
         self.lock_state().reset();
     }
 
-    fn lock(&mut self) -> <Self as QueueGuard>::G {
+    fn lock(&mut self) -> <Self as QueueGuard<'_>>::G {
         self.lock_state()
     }
 


### PR DESCRIPTION
### Summary of the PR

There is a new warning reported by nightly compiler about mismatched lifetime syntaxes. Add the missing lifetime where ever required.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
