### PR TITLE
Update README with Kani proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,32 @@ need to unblock the pipeline by following the Buildkite run link in the PR and
 click on the corresponding
 [unblock pipeline button](https://buildkite.com/docs/pipelines/block-step).
 
+## Kani proofs
+We run Kani proofs for each PR and on merges to the main branch. The proofs
+check conformance of the virtio-queue implementation to requirements from the
+virtio specification. Different than a unit test, a proof is checked for every
+possible input thus enforcing conformance. To run Kani locally, please first
+follow this
+[link](https://model-checking.github.io/kani/install-guide.html#installing-the-latest-version)
+to install it. Then, to run all the proofs in all packages, use the following
+command:
+
+```bash
+cargo kani
+```
+
+To run the proofs in a single package, run:
+
+```bash
+cargo kani --package virtio-queue
+```
+
+To run a single proof, run:
+
+```bash
+cargo kani --exact --harness queue::verification::verify_spec_2_7_7_2
+```
+
 ## License
 
 This project is licensed under either of


### PR DESCRIPTION
### Summary of the PR

Update README with existing Kani proofs. This PR is regarding the addition of the first proof at https://github.com/rust-vmm/vm-virtio/pull/338. I am not sure if the README shall mention the existing PRs because that will force people to keep it update. At the same time, it may be useful for users to know which requirements from the specification are proved to be conform to.

Closes: #353

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
