### PR TITLE
Update vm-memory dependency to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
-vm-memory = "0.17.1"
+vm-memory = "0.18.0"
 vmm-sys-util = "0.15.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ memfd = "0.6.3"
 virtio-queue = { path = "../virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../virtio-vsock" }
 virtio-queue-ser = { path = "../virtio-queue-ser" }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.18.0", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
 virtio-blk = { path = "../virtio-blk", features = ["backend-stdio"] }
 

--- a/fuzz/common/Cargo.toml
+++ b/fuzz/common/Cargo.toml
@@ -13,4 +13,4 @@ virtio-queue = { path = "../../virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../../virtio-vsock" }
 virtio-queue-ser = { path = "../../virtio-queue-ser" }
 virtio-blk = { path = "../../virtio-blk" }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.18.0", features = ["backend-mmap", "backend-atomic"] }

--- a/fuzz/common/src/vsock.rs
+++ b/fuzz/common/src/vsock.rs
@@ -199,6 +199,33 @@ mod tests {
     const HEADER_WRITE_ADDR: u64 = 0x100;
     const DATA_WRITE_ADDR: u64 = 0x1000;
 
+    /// For `get_mem_ptr()`: Whether we access the RX or TX ring.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    enum RxTx {
+        /// Receive ring
+        Rx,
+        /// Transmission ring
+        Tx,
+    }
+
+    /// Return a host pointer to the slice at `[addr, addr + length)`.  Use this only for
+    /// comparison in `assert_eq!()`.
+    fn get_mem_ptr<M: GuestMemory>(
+        mem: &M,
+        addr: GuestAddress,
+        length: usize,
+        _rx_tx: RxTx,
+    ) -> *const u8 {
+        assert!(length > 0);
+        let slice = mem
+            .get_slices(addr, length)
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(slice.len(), length, "Fragmented guest memory area");
+        slice.ptr_guard().as_ptr()
+    }
+
     // We are generating the same operations for packets created from either RX or TX.
     // Because we need as a first function the write to memory, we are passing the functions as
     // both an input & output parameter even though this is typically an anti-pattern.
@@ -206,6 +233,7 @@ mod tests {
         packet: &mut VsockPacket<B>,
         mem: &GuestMemoryMmap,
         functions: &mut Vec<VsockFunction>,
+        rx_tx: RxTx,
     ) {
         // We are actually calling the functions that we want the fuzzer to call to validate
         // the test case. To easily track the functions and their order, we just add them to
@@ -214,15 +242,19 @@ mod tests {
         functions.push(VsockFunction::HeaderSlice);
         assert_eq!(
             header_slice.ptr_guard().as_ptr(),
-            mem.get_host_address(GuestAddress(HEADER_WRITE_ADDR))
-                .unwrap()
+            get_mem_ptr(
+                mem,
+                GuestAddress(HEADER_WRITE_ADDR),
+                header_slice.len(),
+                rx_tx
+            )
         );
 
         let data_slice = packet.data_slice().unwrap();
         functions.push(VsockFunction::DataSlice);
         assert_eq!(
             data_slice.ptr_guard().as_ptr(),
-            mem.get_host_address(GuestAddress(DATA_WRITE_ADDR)).unwrap()
+            get_mem_ptr(mem, GuestAddress(DATA_WRITE_ADDR), data_slice.len(), rx_tx)
         );
 
         packet.set_src_cid(SRC_CID);
@@ -338,7 +370,7 @@ mod tests {
 
         let mut packet =
             VsockPacket::from_tx_virtq_chain(&mem, &mut chain, MAX_PKT_BUF_SIZE).unwrap();
-        create_basic_vsock_packet_ops(&mut packet, &mem, &mut functions);
+        create_basic_vsock_packet_ops(&mut packet, &mem, &mut functions, RxTx::Tx);
         let vsock_fuzz_input = VsockInput {
             functions,
             descriptors,
@@ -389,7 +421,7 @@ mod tests {
         let mut packet =
             VsockPacket::from_rx_virtq_chain(&mem, &mut chain, MAX_PKT_BUF_SIZE).unwrap();
         let mut functions = Vec::new();
-        create_basic_vsock_packet_ops(&mut packet, &mem, &mut functions);
+        create_basic_vsock_packet_ops(&mut packet, &mem, &mut functions, RxTx::Rx);
         let vsock_fuzz_input = VsockInput {
             functions,
             descriptors,

--- a/virtio-blk/src/request.rs
+++ b/virtio-blk/src/request.rs
@@ -24,6 +24,7 @@
 //! approach.
 
 use std::fmt::{self, Display};
+use std::mem::size_of;
 use std::ops::Deref;
 use std::result;
 
@@ -179,9 +180,12 @@ impl Request {
 
         // Check that the address of the status is valid in guest memory.
         // We will write an u8 status here after executing the request.
-        let _ = mem.check_address(desc.addr()).ok_or_else(|| {
-            Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(desc.addr()))
-        })?;
+        if !mem.check_range(desc.addr(), size_of::<u8>()) {
+            return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
+                desc.addr(),
+            )));
+        }
+
         Ok(())
     }
 

--- a/virtio-blk/src/request.rs
+++ b/virtio-blk/src/request.rs
@@ -37,7 +37,7 @@ use virtio_queue::{
     desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
     DescriptorChain,
 };
-use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError};
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, Permissions};
 
 /// Block request parsing errors.
 #[derive(Debug)]
@@ -180,7 +180,7 @@ impl Request {
 
         // Check that the address of the status is valid in guest memory.
         // We will write an u8 status here after executing the request.
-        if !mem.check_range(desc.addr(), size_of::<u8>()) {
+        if !mem.check_range(desc.addr(), size_of::<u8>(), Permissions::Write) {
             return Err(Error::GuestMemory(GuestMemoryError::InvalidGuestAddress(
                 desc.addr(),
             )));

--- a/virtio-queue-ser/CHANGELOG.md
+++ b/virtio-queue-ser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+- Updated vm-memory from 0.17.1 to 0.18.0
+
 ## Fixed
 
 # v0.14.0

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+- Updated vm-memory from 0.17.1 to 0.18.0
+
 ## Fixed
 
 # v0.17.0

--- a/virtio-queue/src/chain.rs
+++ b/virtio-queue/src/chain.rs
@@ -15,7 +15,7 @@ use std::mem::size_of;
 use std::ops::Deref;
 
 use vm_memory::bitmap::{BitmapSlice, WithBitmapSlice};
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryRegion};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
 
 use crate::{desc::split::Descriptor, Error, Reader, Writer};
 use virtio_bindings::bindings::virtio_ring::VRING_DESC_ALIGN_SIZE;
@@ -92,7 +92,7 @@ where
     pub fn writer<'a, B: BitmapSlice>(self, mem: &'a M::Target) -> Result<Writer<'a, B>, Error>
     where
         M::Target: Sized,
-        <<M::Target as GuestMemory>::R as GuestMemoryRegion>::B: WithBitmapSlice<'a, S = B>,
+        <M::Target as GuestMemory>::Bitmap: WithBitmapSlice<'a, S = B>,
     {
         Writer::new(mem, self).map_err(|_| Error::InvalidChain)
     }
@@ -101,7 +101,7 @@ where
     pub fn reader<'a, B: BitmapSlice>(self, mem: &'a M::Target) -> Result<Reader<'a, B>, Error>
     where
         M::Target: Sized,
-        <<M::Target as GuestMemory>::R as GuestMemoryRegion>::B: WithBitmapSlice<'a, S = B>,
+        <M::Target as GuestMemory>::Bitmap: WithBitmapSlice<'a, S = B>,
     {
         Reader::new(mem, self).map_err(|_| Error::InvalidChain)
     }

--- a/virtio-queue/src/descriptor_utils.rs
+++ b/virtio-queue/src/descriptor_utils.rs
@@ -15,9 +15,7 @@ use std::{cmp, result};
 
 use crate::{DescriptorChain, Error};
 use vm_memory::bitmap::{BitmapSlice, WithBitmapSlice};
-use vm_memory::{
-    Address, ByteValued, GuestMemory, GuestMemoryRegion, MemoryRegionAddress, VolatileSlice,
-};
+use vm_memory::{ByteValued, GuestMemory, GuestMemoryRegion, VolatileSlice};
 
 pub type Result<T> = result::Result<T, Error>;
 
@@ -165,28 +163,22 @@ impl<'a, B: BitmapSlice> Reader<'a, B> {
         T::Target: GuestMemory + Sized,
     {
         let mut total_len: usize = 0;
-        let buffers = desc_chain
-            .readable()
-            .map(|desc| {
-                // Verify that summing the descriptor sizes does not overflow.
-                // This can happen if a driver tricks a device into reading more data than
-                // fits in a `usize`.
-                total_len = total_len
-                    .checked_add(desc.len() as usize)
-                    .ok_or(Error::DescriptorChainOverflow)?;
+        let mut buffers = VecDeque::<VolatileSlice<'a, B>>::new();
 
-                let region = mem
-                    .find_region(desc.addr())
-                    .ok_or(Error::FindMemoryRegion)?;
-                let offset = desc
-                    .addr()
-                    .checked_sub(region.start_addr().raw_value())
-                    .unwrap();
-                region
-                    .get_slice(MemoryRegionAddress(offset.raw_value()), desc.len() as usize)
-                    .map_err(Error::GuestMemoryError)
-            })
-            .collect::<Result<VecDeque<VolatileSlice<'a, B>>>>()?;
+        for desc in desc_chain.readable() {
+            // Verify that summing the descriptor sizes does not overflow.
+            // This can happen if a driver tricks a device into reading more data than
+            // fits in a `usize`.
+            total_len = total_len
+                .checked_add(desc.len() as usize)
+                .ok_or(Error::DescriptorChainOverflow)?;
+
+            let slices = mem.get_slices(desc.addr(), desc.len() as usize);
+            for slice in slices {
+                buffers.push_back(slice.map_err(Error::GuestMemoryError)?);
+            }
+        }
+
         Ok(Reader {
             buffer: DescriptorChainConsumer {
                 buffers,
@@ -277,28 +269,21 @@ impl<'a, B: BitmapSlice> Writer<'a, B> {
         T::Target: GuestMemory + Sized,
     {
         let mut total_len: usize = 0;
-        let buffers = desc_chain
-            .writable()
-            .map(|desc| {
-                // Verify that summing the descriptor sizes does not overflow.
-                // This can happen if a driver tricks a device into writing more data than
-                // fits in a `usize`.
-                total_len = total_len
-                    .checked_add(desc.len() as usize)
-                    .ok_or(Error::DescriptorChainOverflow)?;
+        let mut buffers = VecDeque::<VolatileSlice<'a, B>>::new();
 
-                let region = mem
-                    .find_region(desc.addr())
-                    .ok_or(Error::FindMemoryRegion)?;
-                let offset = desc
-                    .addr()
-                    .checked_sub(region.start_addr().raw_value())
-                    .unwrap();
-                region
-                    .get_slice(MemoryRegionAddress(offset.raw_value()), desc.len() as usize)
-                    .map_err(Error::GuestMemoryError)
-            })
-            .collect::<Result<VecDeque<VolatileSlice<'a, B>>>>()?;
+        for desc in desc_chain.writable() {
+            // Verify that summing the descriptor sizes does not overflow.
+            // This can happen if a driver tricks a device into writing more data than
+            // fits in a `usize`.
+            total_len = total_len
+                .checked_add(desc.len() as usize)
+                .ok_or(Error::DescriptorChainOverflow)?;
+
+            let slices = mem.get_slices(desc.addr(), desc.len() as usize);
+            for slice in slices {
+                buffers.push_back(slice.map_err(Error::GuestMemoryError)?);
+            }
+        }
 
         Ok(Writer {
             buffer: DescriptorChainConsumer {
@@ -369,7 +354,7 @@ mod tests {
         desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
         Queue, QueueOwnedT, QueueT,
     };
-    use vm_memory::{GuestAddress, GuestMemoryMmap, Le32};
+    use vm_memory::{Address, GuestAddress, GuestMemoryMmap, Le32};
 
     use crate::mock::MockSplitQueue;
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};

--- a/virtio-queue/src/queue.rs
+++ b/virtio-queue/src/queue.rs
@@ -313,32 +313,23 @@ impl QueueT for Queue {
         if !self.ready {
             error!("attempt to use virtio queue that is not marked ready");
             false
-        } else if desc_table
-            .checked_add(desc_table_size)
-            .is_none_or(|v| !mem.address_in_range(v))
-        {
+        } else if !mem.check_range(desc_table, desc_table_size as usize) {
             error!(
-                "virtio queue descriptor table goes out of bounds: start:0x{:08x} size:0x{:08x}",
+                "virtio queue descriptor table is not accessible: start:0x{:08x} size:0x{:08x}",
                 desc_table.raw_value(),
                 desc_table_size
             );
             false
-        } else if avail_ring
-            .checked_add(avail_ring_size)
-            .is_none_or(|v| !mem.address_in_range(v))
-        {
+        } else if !mem.check_range(avail_ring, avail_ring_size as usize) {
             error!(
-                "virtio queue available ring goes out of bounds: start:0x{:08x} size:0x{:08x}",
+                "virtio queue available ring is not accessible: start:0x{:08x} size:0x{:08x}",
                 avail_ring.raw_value(),
                 avail_ring_size
             );
             false
-        } else if used_ring
-            .checked_add(used_ring_size)
-            .is_none_or(|v| !mem.address_in_range(v))
-        {
+        } else if !mem.check_range(used_ring, used_ring_size as usize) {
             error!(
-                "virtio queue used ring goes out of bounds: start:0x{:08x} size:0x{:08x}",
+                "virtio queue used ring is not accessible: start:0x{:08x} size:0x{:08x}",
                 used_ring.raw_value(),
                 used_ring_size
             );

--- a/virtio-queue/src/queue.rs
+++ b/virtio-queue/src/queue.rs
@@ -12,7 +12,7 @@ use std::num::Wrapping;
 use std::ops::Deref;
 use std::sync::atomic::{fence, Ordering};
 
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, Permissions};
 
 use crate::defs::{
     DEFAULT_AVAIL_RING_ADDR, DEFAULT_DESC_TABLE_ADDR, DEFAULT_USED_RING_ADDR,
@@ -313,21 +313,21 @@ impl QueueT for Queue {
         if !self.ready {
             error!("attempt to use virtio queue that is not marked ready");
             false
-        } else if !mem.check_range(desc_table, desc_table_size as usize) {
+        } else if !mem.check_range(desc_table, desc_table_size as usize, Permissions::Read) {
             error!(
                 "virtio queue descriptor table is not accessible: start:0x{:08x} size:0x{:08x}",
                 desc_table.raw_value(),
                 desc_table_size
             );
             false
-        } else if !mem.check_range(avail_ring, avail_ring_size as usize) {
+        } else if !mem.check_range(avail_ring, avail_ring_size as usize, Permissions::Read) {
             error!(
                 "virtio queue available ring is not accessible: start:0x{:08x} size:0x{:08x}",
                 avail_ring.raw_value(),
                 avail_ring_size
             );
             false
-        } else if !mem.check_range(used_ring, used_ring_size as usize) {
+        } else if !mem.check_range(used_ring, used_ring_size as usize, Permissions::Write) {
             error!(
                 "virtio queue used ring is not accessible: start:0x{:08x} size:0x{:08x}",
                 used_ring.raw_value(),

--- a/virtio-queue/src/queue/verification.rs
+++ b/virtio-queue/src/queue/verification.rs
@@ -3,8 +3,8 @@ use std::mem::ManuallyDrop;
 use std::num::Wrapping;
 
 use vm_memory::{
-    AtomicAccess, GuestMemoryError, GuestMemoryRegion, GuestMemoryResult, MemoryRegionAddress,
-    VolatileSlice,
+    AtomicAccess, GuestMemoryBackend, GuestMemoryError, GuestMemoryRegion, GuestMemoryResult,
+    MemoryRegionAddress, VolatileSlice,
 };
 
 use std::mem::MaybeUninit;
@@ -335,7 +335,7 @@ struct SingleRegionGuestMemory {
     the_region: StubRegion,
 }
 
-impl GuestMemory for SingleRegionGuestMemory {
+impl GuestMemoryBackend for SingleRegionGuestMemory {
     type R = StubRegion;
 
     fn num_regions(&self) -> usize {
@@ -359,7 +359,7 @@ impl GuestMemory for SingleRegionGuestMemory {
     /// be a single slice, so we can assert that here and check that single one, keeping kani
     /// content.
     fn check_range(&self, base: GuestAddress, len: usize) -> bool {
-        let mut slices = GuestMemory::get_slices(self, base, len);
+        let mut slices = GuestMemoryBackend::get_slices(self, base, len);
         let result = slices.next().map_or(true, |r| r.is_ok());
         // We only have a single region, so `get_slices()` must never return more than one slice
         assert!(slices.next().is_none());

--- a/virtio-vsock/CHANGELOG.md
+++ b/virtio-vsock/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+- Updated vm-memory from 0.17.1 to 0.18.0
+
 ## Fixed
 
 # v0.11.0

--- a/virtio-vsock/src/packet.rs
+++ b/virtio-vsock/src/packet.rs
@@ -38,8 +38,8 @@ use std::ops::Deref;
 use virtio_queue::DescriptorChain;
 use vm_memory::bitmap::{BitmapSlice, WithBitmapSlice};
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestMemory, GuestMemoryError, GuestMemoryRegion, Le16, Le32, Le64,
-    VolatileMemoryError, VolatileSlice,
+    Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryRegion,
+    Le16, Le32, Le64, VolatileMemoryError, VolatileSlice,
 };
 
 /// Vsock packet parsing errors.
@@ -51,6 +51,8 @@ pub enum Error {
     DescriptorLengthTooSmall,
     /// Descriptor that was too long to use.
     DescriptorLengthTooLong,
+    /// Data stretches over multiple memory fragments
+    FragmentedMemory,
     /// The slice for creating a header has an invalid length.
     InvalidHeaderInputSize(usize),
     /// The `len` header field value exceeds the maximum allowed data size.
@@ -81,6 +83,9 @@ impl Display for Error {
                 f,
                 "The descriptor is pointing to a buffer that has a longer length than expected."
             ),
+            Error::FragmentedMemory => {
+                write!(f, "Data stretches over multiple memory fragments.")
+            }
             Error::InvalidHeaderInputSize(size) => {
                 write!(f, "Invalid header input size: {size}")
             }
@@ -175,6 +180,40 @@ macro_rules! set_header_field {
             // This unwrap is safe only if `$offset` is a valid offset in the `header_slice`.
             .unwrap();
     };
+}
+
+/// Get a single slice for `[addr, addr + count)`.
+///
+/// This is a replacement for the deprecated `GuestMemory::get_slice()` function: It calls
+/// `mem.get_slices()` and will return the first slice from the iterator, if any.  If that slice
+/// does not cover the request length (i.e. the requested region would translate into multiple
+/// slices), return `Err(Error::FragmentedMemory)`.
+///
+/// If `count == 0`, this function will always return `Ok(None)`.  Otherwise, it will always return
+/// an error or `Ok(Some(slice))`.
+fn get_single_slice<'a, M: GuestMemory, B: BitmapSlice>(
+    mem: &'a M,
+    addr: GuestAddress,
+    count: usize,
+) -> Result<Option<VolatileSlice<'a, B>>>
+where
+    <M::R as GuestMemoryRegion>::B: WithBitmapSlice<'a, S = B>,
+{
+    if count == 0 {
+        return Ok(None);
+    }
+
+    let slice = mem
+        .get_slices(addr, count)
+        .next()
+        .expect("Expecting some result for a non-empty memory region")
+        .map_err(Error::InvalidMemoryAccess)?;
+
+    if slice.len() == count {
+        Ok(Some(slice))
+    } else {
+        Err(Error::FragmentedMemory)
+    }
 }
 
 impl<'a, B: BitmapSlice> VsockPacket<'a, B> {
@@ -435,9 +474,8 @@ impl<'a, B: BitmapSlice> VsockPacket<'a, B> {
             return Err(Error::DescriptorLengthTooSmall);
         }
 
-        let header_slice = mem
-            .get_slice(chain_head.addr(), PKT_HEADER_SIZE)
-            .map_err(Error::InvalidMemoryAccess)?;
+        let header_slice = get_single_slice(mem, chain_head.addr(), PKT_HEADER_SIZE)?
+            .expect("Received empty mapping for non-zero PKT_HEADER_SIZE");
 
         let header = mem
             .read_obj(chain_head.addr())
@@ -463,14 +501,15 @@ impl<'a, B: BitmapSlice> VsockPacket<'a, B> {
         // header and data.
         let data_slice =
             if !chain_head.has_next() && chain_head.len() - PKT_HEADER_SIZE as u32 >= pkt.len() {
-                mem.get_slice(
+                get_single_slice(
+                    mem,
                     chain_head
                         .addr()
                         .checked_add(PKT_HEADER_SIZE as u64)
                         .ok_or(Error::DescriptorLengthTooSmall)?,
                     pkt.len() as usize,
-                )
-                .map_err(Error::InvalidMemoryAccess)?
+                )?
+                .expect("Received empty mapping for non-empty packet")
             } else {
                 if !chain_head.has_next() {
                     return Err(Error::DescriptorChainTooShort);
@@ -488,8 +527,8 @@ impl<'a, B: BitmapSlice> VsockPacket<'a, B> {
                     return Err(Error::DescriptorLengthTooSmall);
                 }
 
-                mem.get_slice(data_desc.addr(), pkt.len() as usize)
-                    .map_err(Error::InvalidMemoryAccess)?
+                get_single_slice(mem, data_desc.addr(), pkt.len() as usize)?
+                    .expect("Received empty mapping for non-empty packet")
             };
 
         pkt.data_slice = Some(data_slice);
@@ -596,21 +635,20 @@ impl<'a, B: BitmapSlice> VsockPacket<'a, B> {
             return Err(Error::DescriptorLengthTooSmall);
         }
 
-        let header_slice = mem
-            .get_slice(chain_head.addr(), PKT_HEADER_SIZE)
-            .map_err(Error::InvalidMemoryAccess)?;
+        let header_slice = get_single_slice(mem, chain_head.addr(), PKT_HEADER_SIZE)?
+            .expect("Received empty mapping for non-zero PKT_HEADER_SIZE");
 
         // Starting from Linux 6.2 the virtio-vsock driver can use a single descriptor for both
         // header and data.
         let data_slice = if !chain_head.has_next() && chain_head.len() as usize > PKT_HEADER_SIZE {
-            mem.get_slice(
+            get_single_slice(
+                mem,
                 chain_head
                     .addr()
                     .checked_add(PKT_HEADER_SIZE as u64)
                     .ok_or(Error::DescriptorLengthTooSmall)?,
                 chain_head.len() as usize - PKT_HEADER_SIZE,
-            )
-            .map_err(Error::InvalidMemoryAccess)?
+            )?
         } else {
             if !chain_head.has_next() {
                 return Err(Error::DescriptorChainTooShort);
@@ -626,14 +664,14 @@ impl<'a, B: BitmapSlice> VsockPacket<'a, B> {
                 return Err(Error::DescriptorLengthTooLong);
             }
 
-            mem.get_slice(data_desc.addr(), data_desc.len() as usize)
-                .map_err(Error::InvalidMemoryAccess)?
+            get_single_slice(mem, data_desc.addr(), data_desc.len() as usize)?
         };
 
         Ok(Self {
             header_slice,
             header: Default::default(),
-            data_slice: Some(data_slice),
+            // `None` if and only if the length is 0
+            data_slice,
         })
     }
 }
@@ -690,6 +728,7 @@ mod tests {
                 (DescriptorChainTooShort, DescriptorChainTooShort) => true,
                 (DescriptorLengthTooSmall, DescriptorLengthTooSmall) => true,
                 (DescriptorLengthTooLong, DescriptorLengthTooLong) => true,
+                (FragmentedMemory, FragmentedMemory) => true,
                 (InvalidHeaderInputSize(size), InvalidHeaderInputSize(other_size)) => {
                     size == other_size
                 }
@@ -838,7 +877,7 @@ mod tests {
         let mut chain = queue.build_desc_chain(&v).unwrap();
         assert_eq!(
             VsockPacket::from_rx_virtq_chain(&mem, &mut chain, MAX_PKT_BUF_SIZE).unwrap_err(),
-            Error::InvalidMemoryAccess(GuestMemoryError::InvalidBackendAddress)
+            Error::FragmentedMemory
         );
 
         let v = vec![
@@ -897,7 +936,7 @@ mod tests {
         let mut chain = queue.build_desc_chain(&v).unwrap();
         assert_eq!(
             VsockPacket::from_rx_virtq_chain(&mem, &mut chain, MAX_PKT_BUF_SIZE).unwrap_err(),
-            Error::InvalidMemoryAccess(GuestMemoryError::InvalidBackendAddress)
+            Error::FragmentedMemory
         );
 
         let v = vec![
@@ -1075,7 +1114,7 @@ mod tests {
         let mut chain = queue.build_desc_chain(&v).unwrap();
         assert_eq!(
             VsockPacket::from_tx_virtq_chain(&mem, &mut chain, MAX_PKT_BUF_SIZE).unwrap_err(),
-            Error::InvalidMemoryAccess(GuestMemoryError::InvalidBackendAddress)
+            Error::FragmentedMemory
         );
 
         let v = vec![
@@ -1148,7 +1187,7 @@ mod tests {
         let mut chain = queue.build_desc_chain(&v).unwrap();
         assert_eq!(
             VsockPacket::from_tx_virtq_chain(&mem, &mut chain, MAX_PKT_BUF_SIZE).unwrap_err(),
-            Error::InvalidMemoryAccess(GuestMemoryError::InvalidBackendAddress)
+            Error::FragmentedMemory
         );
 
         let v = vec![


### PR DESCRIPTION
### Summary of the PR

Update the vm-memory dependency to 0.18.0. This PR supersedes https://github.com/rust-vmm/vm-virtio/pull/378.

0.18.0 is a breaking change, first and foremost because it renames the `GuestMemory` trait to `GuestMemoryBackend`, replacing it with a new `GuestMemory` trait that can abstract not only physical but also virtual memory, but in turn has a limited interface and requires specifying the required permissions for any memory access.

(Luckily, most memory accesses use the `Bytes` trait, which already implicitly specifies the access mode by way of which method is used, e.g. `load()` vs. `store()`.)

This PR first changes some calls to use the methods that will still be available:
* `check_range()` instead of `check_address()`
* Specifically for `virtio_queue::descriptor_utils::{Reader, Writer}::new()`: Do not resolve memory accesses through guest memory regions, just collect slices through `get_slices()`
* For `virtio_vsock::packet`: Replace `get_slice()` by a helper function that calls `get_slices()` and returns an error if the given guest memory region maps to more than a single slice. This is not ideal: `get_slice()` has been removed to make users aware that guest memory regions may not always map to a single slice in their memory, especially for virtual memory, and this is just ignoring that. However, it shouldn’t be a regression, so support for this can be implemented later, I think. (Maybe via bounce buffers if the interface must stay compatible?)
* `get_host_address()` is removed; we only need it for testing, so we can just use `get_single_slice().as_ptr()` there, basically.

Then it bumps the vm-memory version, at which point we need to:
* Pass the required access permissions,
* Deal with `get_slices()` returning a `Result<Iterator, E>` instead of a plain `Iterator`,
* Get the bitmap type via `GuestMemory::Bitmap` instead of `<GuestMemory::R as GuestMemoryRegion>::B`, and
* Make the verification code’s `SingleRegionGuestMemory` implement `GuestMemoryBackend` instead of `GuestMemory`.

#### Compatibility Note

Note that users should still be able to depend on vm-memory 0.17.2+, even with vm-virtio updating to 0.18.0. This is because 0.17.2 internally depends on 0.18.0 and just re-exports all symbols, just some under different names (i.e. `GuestMemoryBackend` as `GuestMemory`).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
