### PR TITLE
virtio-bindings: Prepare v0.2.7 release

### DIFF
--- a/virtio-bindings/CHANGELOG.md
+++ b/virtio-bindings/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Upcoming Release
 
+# v0.2.7
+
 ## Changed
 
 - Regenerate bindings with Linux 6.16.
@@ -8,6 +10,7 @@
 ## Fixed
 
 - Fix powerpc64 little-endian bindings.
+- Fix several architecture-specific issues introduced in the previous release
 
 # v0.2.6
 

--- a/virtio-bindings/Cargo.toml
+++ b/virtio-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-bindings"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 description = "Rust FFI bindings to virtio generated using bindgen."
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
Changed

- Regenerate bindings with Linux 6.16.
- Drop powerpc (32-bit) bindings.

Fixed

- Fix powerpc64 little-endian bindings.
- Fix several architecture-specific issues introduced in the previous release