### PR TITLE
Release virtio-queue 0.17.1 for vm-memory 0.17.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
-vm-memory = "0.17.1"
+vm-memory = { version = ">=0.17.1, <0.18.0" }
 vmm-sys-util = "0.15.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ memfd = "0.6.3"
 virtio-queue = { path = "../virtio-queue", features = ["test-utils"] }
 virtio-vsock = { path = "../virtio-vsock" }
 virtio-queue-ser = { path = "../virtio-queue-ser" }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.17.2", features = ["backend-mmap", "backend-atomic"] }
 common = { path = "common" }
 virtio-blk = { path = "../virtio-blk", features = ["backend-stdio"] }
 

--- a/virtio-queue-ser/CHANGELOG.md
+++ b/virtio-queue-ser/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+- Relax the dependency on `virtio-queue` to use API compatible version rather than exact version.
+
 ## Fixed
 
 # v0.14.0

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -18,8 +18,8 @@ versionize_derive = "0.1.3"
 # 1:1-relationship between virtio-queue and virtio-queue-ser releases. This is
 # to prevent accidental changes to the serializer output in a patch release of
 # virtio-queue.
-virtio-queue = { path = "../virtio-queue", version = "=0.17.0" }
+virtio-queue = { path = "../virtio-queue", version = "0.17.0" }
 vm-memory = { workspace = true }
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "=0.17.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "0.17.0", features = ["test-utils"] }

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ## Changed
 
-- Relaxed vm-memory requirements to support using 0.17.2
-
 ## Fixed
+
+# v0.17.1
+
+## Changed
+
+- Relaxed vm-memory requirements to support using 0.17.2
 
 # v0.17.0
 

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+- Relaxed vm-memory requirements to support using 0.17.2
+
 ## Fixed
 
 # v0.17.0

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["The Chromium OS Authors"]
 description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"


### PR DESCRIPTION
### Summary of the PR

Prepare a new release of virtio-queue to 0.17.1 to allow use of vm-memory
0.17.2

- **virtio-queue: Relax dependency on vm-memory**
- **fuzz: Bump vm-memory in use to 0.17.2 release**
- **virtio-queue-ser: Relax version for virtio-queue**
- **virtio-queue: Prepare 0.17.1 release**

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
