### PR TITLE
virtio-queue-ser: remove versionize support

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,3 @@
 [advisories]
 ignore = [
-    # bincode is an unmaintained dependency introduced by versionize.
-    # Issue reported at https://github.com/firecracker-microvm/versionize/issues/63
-    # While waiting for a solution, let's ignore it since it's just unmaintained.
-    "RUSTSEC-2025-0141",
 ]

--- a/virtio-queue-ser/CHANGELOG.md
+++ b/virtio-queue-ser/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updated vm-memory from 0.17.1 to 0.18.0
 
+## Removed
+
+- Remove versionize support
+
 ## Fixed
 
 # v0.14.0

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -11,8 +11,6 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.27", features = ["derive"] }
-versionize = "0.2.0"
-versionize_derive = "0.1.3"
 # The `path` part gets stripped when publishing the crate.
 # We use strict version dependencies (`=x.y.z`) as we maintain a
 # 1:1-relationship between virtio-queue and virtio-queue-ser releases. This is

--- a/virtio-queue-ser/README.md
+++ b/virtio-queue-ser/README.md
@@ -4,22 +4,13 @@ This crate is a companion to [virtio-queue](https://crates.io/crates/virtio-queu
 focusing on persistent state representation for use cases such as (de)serialization.
 The main abstraction is the `QueueStateSer` object, which can be converted to and
 from `QueueState` via the provided `From` trait implementations. `virtio-queue-ser` currently
-supports (de)serialization of `QueueStateSer` objects via [serde](https://crates.io/crates/serde)
-and [versionize](https://crates.io/crates/versionize). The former always serializes the latest
-version of `QueueStateSer`, whereas multiple versions will be supported with `versionize` as
-breaking changes are introduced to `QueueState` (and, by extension, `QueueStateSer`).
+supports (de)serialization of `QueueStateSer` objects via [serde](https://crates.io/crates/serde).
 
 On serialization, the typical workflow is to start from a `state: QueueState` object, obtain
 the corresponding `QueueStateSer` (i.e. `state_ser = QueueStateSer::from(&state)`), then write
-the serialized data using the underlying backend (i.e. `serde` or `versionize`). When deserializing,
+the serialized data using the underlying backend (i.e. `serde`). When deserializing,
 we first get a `state_ser: QueueStateSer` object from the backend, and then convert it to a
 `QueueState` (for example, `state = QueueState::from(&state_ser)`).
-
-When a `versionize`-based backend is used, the state transformations required to transition between
-versions are transparent to consumers of `virtio-queue-ser`. For example, if an older version of
-`QueueStateSer` has been serialized with `versionize`, and we're deserializing based on that data,
-then the `QueueStateSer` object obtained via `versionize` will automatically include any changes
-required for converting to the current version.
 
 ## License
 

--- a/virtio-queue-ser/src/lib.rs
+++ b/virtio-queue-ser/src/lib.rs
@@ -5,7 +5,7 @@
 //! Adds serialization capabilities to the state objects from `virtio-queue`.
 //!
 //! Provides wrappers over the state objects from `virtio-queue` crate that
-//! implement the `Serialize`, `Deserialize` and `Versionize` traits.
+//! implement the `serde::Serialize/Deserialize` traits.
 
 #![deny(missing_docs)]
 

--- a/virtio-queue-ser/src/state.rs
+++ b/virtio-queue-ser/src/state.rs
@@ -2,12 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 use serde::{Deserialize, Serialize};
-use versionize::{VersionMap, Versionize, VersionizeResult};
-use versionize_derive::Versionize;
 use virtio_queue::QueueState;
 
 /// Wrapper over a `QueueState` that has serialization capabilities.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Versionize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct QueueStateSer {
     /// The maximum size in elements offered by the device.
     pub max_size: u16,


### PR DESCRIPTION
versionize crate depends on the deprecated bincode crate and it is on a path to deprecation as well.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
