### PR TITLE
virtio-queue: Prepare v0.18.0 release

### DIFF
--- a/virtio-console/Cargo.toml
+++ b/virtio-console/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2021"
 
 [dependencies]
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.6" }
-virtio-queue = { path = "../virtio-queue", version = "0.17.0" }
+virtio-queue = { path = "../virtio-queue", version = "0.18.0" }
 vm-memory = { workspace = true }
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.17.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "0.18.0", features = ["test-utils"] }
 vm-memory = { workspace = true, features = ["backend-mmap"] }

--- a/virtio-device/Cargo.toml
+++ b/virtio-device/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 vm-memory = { workspace = true }
 log = "0.4.17"
 virtio-bindings = { path = "../virtio-bindings" }
-virtio-queue = { path = "../virtio-queue", version = "0.17.0"}
+virtio-queue = { path = "../virtio-queue", version = "0.18.0"}
 
 [dev-dependencies]
 vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }

--- a/virtio-queue-ser/Cargo.toml
+++ b/virtio-queue-ser/Cargo.toml
@@ -16,8 +16,8 @@ serde = { version = "1.0.27", features = ["derive"] }
 # 1:1-relationship between virtio-queue and virtio-queue-ser releases. This is
 # to prevent accidental changes to the serializer output in a patch release of
 # virtio-queue.
-virtio-queue = { path = "../virtio-queue", version = "=0.17.0" }
+virtio-queue = { path = "../virtio-queue", version = "=0.18.0" }
 vm-memory = { workspace = true }
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "=0.17.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "=0.18.0", features = ["test-utils"] }

--- a/virtio-queue/CHANGELOG.md
+++ b/virtio-queue/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Added
 
+## Changed
+
+## Fixed
+
+# v0.18.0
+
+## Added
+
 - Implement `From<Queue>` and `From<Arc<Mutex<Queue>>>` for `QueueSync`
 
 ## Changed

--- a/virtio-queue/Cargo.toml
+++ b/virtio-queue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-queue"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["The Chromium OS Authors"]
 description = "virtio queue implementation"
 repository = "https://github.com/rust-vmm/vm-virtio"

--- a/virtio-vsock/Cargo.toml
+++ b/virtio-vsock/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 
 [dependencies]
 # The `path` part gets stripped when publishing the crate.
-virtio-queue = { path = "../virtio-queue", version = "0.17.0" }
+virtio-queue = { path = "../virtio-queue", version = "0.18.0" }
 virtio-bindings = { path = "../virtio-bindings", version = "0.2.6" }
 vm-memory = { workspace = true }
 
 [dev-dependencies]
-virtio-queue = { path = "../virtio-queue", version = "0.17.0", features = ["test-utils"] }
+virtio-queue = { path = "../virtio-queue", version = "0.18.0", features = ["test-utils"] }
 vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
Added

- Implement `From<Queue>` and `From<Arc<Mutex<Queue>>>` for `QueueSync`

Changed

- Updated vm-memory from 0.17.1 to 0.18.0

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
